### PR TITLE
Update notebooks for JupyterLab 4 upgrade and new SQL cell

### DIFF
--- a/notebooks/atlas-and-kai/notebook.ipynb
+++ b/notebooks/atlas-and-kai/notebook.ipynb
@@ -4,76 +4,37 @@
       "cell_type": "markdown",
       "id": "48a6458f-75ed-4a6c-aaa8-184bb9edfb75",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(235, 249, 245, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/database.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Mongo Atlas &amp; SingleStore Kai</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(235, 249, 245, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/database.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Mongo Atlas &amp; SingleStore Kai</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "ca93a410-d513-42ec-a823-99ad8f3a25c1",
       "metadata": {},
-      "source": [
-        "<img src=https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/atlas-and-kai/images/mongo-db-singlestoredb.png width=\"100%\">"
-      ]
+      "source": "<img src=https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/atlas-and-kai/images/mongo-db-singlestoredb.png width=\"100%\">"
     },
     {
       "cell_type": "markdown",
       "id": "5353b6a2-006f-4a71-834f-045d3e054640",
       "metadata": {},
-      "source": [
-        "# No code change required! 100% MongoDB notebook!\n",
-        "\n",
-        "Given the small dataset, the objective of that notebook is not to compare performance.\n",
-        "\n",
-        "## What you will learn in this notebook:\n",
-        "\n",
-        "1. Install libraries and import modules\n",
-        "2. Connect to a MongoDB Atlas and SingleStoreDB Kai endpoints\n",
-        "3. Copy Atlas collections into SingleStoreDB - Synthetic collections are about retail sales transactions with customer information\n",
-        "\n",
-        "## Compare performance on same code from simple to more complex queries\n",
-        "\n",
-        "4. Document counts\n",
-        "5. Product quantity sold\n",
-        "6. Average customer satisfaction\n",
-        "7. Average satisfaction per product\n",
-        "8. Number of transactions by Location and membership\n",
-        "9. Top 10 product sales"
-      ]
+      "source": "# No code change required! 100% MongoDB notebook!\n\nGiven the small dataset, the objective of that notebook is not to compare performance.\n\n## What you will learn in this notebook:\n\n1. Install libraries and import modules\n2. Connect to a MongoDB Atlas and SingleStoreDB Kai endpoints\n3. Copy Atlas collections into SingleStoreDB - Synthetic collections are about retail sales transactions with customer information\n\n## Compare performance on same code from simple to more complex queries\n\n4. Document counts\n5. Product quantity sold\n6. Average customer satisfaction\n7. Average satisfaction per product\n8. Number of transactions by Location and membership\n9. Top 10 product sales"
     },
     {
       "cell_type": "markdown",
       "id": "a5f3d92f-5721-4f28-a91a-b04def563dfb",
       "metadata": {},
-      "source": [
-        "## 1. Install libraries and import modules"
-      ]
+      "source": "## 1. Install libraries and import modules"
     },
     {
       "cell_type": "markdown",
       "id": "856860b6-c6ac-4f72-8d64-5d405dbb7acc",
       "metadata": {},
-      "source": [
-        "**Make sure that you have a created MongoDB enabled workspace.**\n",
-        "\n",
-        "This must be done when creating a workspace."
-      ]
+      "source": "**Make sure that you have a created MongoDB enabled workspace.**\n\nThis must be done when creating a workspace."
     },
     {
       "cell_type": "markdown",
       "id": "33506e25-c044-4f6f-9d62-df61783076e1",
       "metadata": {},
-      "source": [
-        "<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/atlas-and-kai/images/mongo-enabled-workspace.png\" style=\"width: 500\">"
-      ]
+      "source": "<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/atlas-and-kai/images/mongo-enabled-workspace.png\" style=\"width: 500\">"
     },
     {
       "cell_type": "code",
@@ -81,20 +42,17 @@
       "id": "26ec8d2d-25b1-4b8f-a62f-098192b8d45f",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip install pymongo pandas matplotlib plotly ipywidgets --quiet"
-      ]
+      "source": "!pip install pymongo pandas matplotlib plotly ipywidgets --quiet"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "6087e187-ab0b-4df6-8c9e-ee9fc7153a6b",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "drop database if exists new_transactions"
-      ]
+      "source": "DROP DATABASE IF EXISTS new_transactions"
     },
     {
       "cell_type": "code",
@@ -102,27 +60,13 @@
       "id": "3722ef02-42b0-41af-869a-b4b1f7f62e02",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import os\n",
-        "import time\n",
-        "\n",
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "import plotly.express as px\n",
-        "import plotly.subplots as sp\n",
-        "import pymongo\n",
-        "from pymongo import MongoClient\n",
-        "from plotly.offline import plot, iplot, init_notebook_mode"
-      ]
+      "source": "import os\nimport time\n\nimport numpy as np\nimport pandas as pd\nimport plotly.express as px\nimport plotly.subplots as sp\nimport pymongo\nfrom pymongo import MongoClient\nfrom plotly.offline import plot, iplot, init_notebook_mode"
     },
     {
       "cell_type": "markdown",
       "id": "b96597f7-68e1-45d3-bbb0-dbfb5f440881",
       "metadata": {},
-      "source": [
-        "## 2. Connect to Atlas and SingleStoreDB Kai endpoints\n",
-        "We are using a shared tier on the backend for Atlas"
-      ]
+      "source": "## 2. Connect to Atlas and SingleStoreDB Kai endpoints\nWe are using a shared tier on the backend for Atlas"
     },
     {
       "cell_type": "code",
@@ -130,24 +74,13 @@
       "id": "d038bacc-ae3d-450e-a955-a304f9a07c74",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "# No need to edit anything\n",
-        "myclientmongodb = pymongo.MongoClient(\"mongodb+srv://mongo_sample_reader:SingleStoreRocks27017@cluster1.tfutgo0.mongodb.net/?retryWrites=true&w=majority\")\n",
-        "mydbmongodb = myclientmongodb[\"new_transactions\"]\n",
-        "mongoitems = mydbmongodb[\"items\"]\n",
-        "mongocusts = mydbmongodb[\"custs\"]\n",
-        "mongotxs = mydbmongodb[\"txs\"]"
-      ]
+      "source": "# No need to edit anything\nmyclientmongodb = pymongo.MongoClient(\"mongodb+srv://mongo_sample_reader:SingleStoreRocks27017@cluster1.tfutgo0.mongodb.net/?retryWrites=true&w=majority\")\nmydbmongodb = myclientmongodb[\"new_transactions\"]\nmongoitems = mydbmongodb[\"items\"]\nmongocusts = mydbmongodb[\"custs\"]\nmongotxs = mydbmongodb[\"txs\"]"
     },
     {
       "cell_type": "markdown",
       "id": "4e8f3c25-3399-4095-a034-438617daa5da",
       "metadata": {},
-      "source": [
-        "**Select the workspace that you want to use.**\n",
-        "\n",
-        "<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/atlas-and-kai/images/select-workspace-and-database.png\" style=\"width: 500px; border: 1px solid darkorchid\">"
-      ]
+      "source": "**Select the workspace that you want to use.**\n\n<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/atlas-and-kai/images/select-workspace-and-database.png\" style=\"width: 500px; border: 1px solid darkorchid\">"
     },
     {
       "cell_type": "code",
@@ -155,21 +88,13 @@
       "id": "e53b6983-8c62-4b45-85d5-fb29fb655936",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "s2clientmongodb = pymongo.MongoClient(connection_url_mongo)\n",
-        "s2dbmongodb = s2clientmongodb[\"new_transactions\"]\n",
-        "s2mongoitems = s2dbmongodb[\"items\"]\n",
-        "s2mongocusts = s2dbmongodb[\"custs\"]\n",
-        "s2mongotxs = s2dbmongodb[\"txs\"]  "
-      ]
+      "source": "s2clientmongodb = pymongo.MongoClient(connection_url_mongo)\ns2dbmongodb = s2clientmongodb[\"new_transactions\"]\ns2mongoitems = s2dbmongodb[\"items\"]\ns2mongocusts = s2dbmongodb[\"custs\"]\ns2mongotxs = s2dbmongodb[\"txs\"]  "
     },
     {
       "cell_type": "markdown",
       "id": "a6f36725-4b74-4460-b1c9-a0144159a7b4",
       "metadata": {},
-      "source": [
-        "## 3. Copy Atlas collections into SingleStoreDB Kai"
-      ]
+      "source": "## 3. Copy Atlas collections into SingleStoreDB Kai"
     },
     {
       "cell_type": "code",
@@ -177,23 +102,13 @@
       "id": "5cb978bc-03cc-4477-853d-577fc856ca94",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "mongocollections = [mongoitems, mongocusts, mongotxs]\n",
-        "\n",
-        "for mongo_collection in mongocollections:\n",
-        "    df = pd.DataFrame(list(mongo_collection.find())).reset_index(drop=True)\n",
-        "    data_dict = df.to_dict(\"records\")\n",
-        "    s2mongo_collection = s2dbmongodb[mongo_collection.name]\n",
-        "    s2mongo_collection.insert_many(data_dict)"
-      ]
+      "source": "mongocollections = [mongoitems, mongocusts, mongotxs]\n\nfor mongo_collection in mongocollections:\n    df = pd.DataFrame(list(mongo_collection.find())).reset_index(drop=True)\n    data_dict = df.to_dict(\"records\")\n    s2mongo_collection = s2dbmongodb[mongo_collection.name]\n    s2mongo_collection.insert_many(data_dict)"
     },
     {
       "cell_type": "markdown",
       "id": "5b3928f8-2487-4553-962f-eb5bc2d83096",
       "metadata": {},
-      "source": [
-        "Count documents in SingleStoreDB."
-      ]
+      "source": "Count documents in SingleStoreDB."
     },
     {
       "cell_type": "code",
@@ -201,36 +116,25 @@
       "id": "91ce2d6e-3d02-4c57-88f7-365d7449d84c",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "mg_count = s2mongoitems.count_documents({})\n",
-        "mg_count"
-      ]
+      "source": "mg_count = s2mongoitems.count_documents({})\nmg_count"
     },
     {
       "cell_type": "markdown",
       "id": "48841366-41fb-45f6-81d7-323cda1b1df7",
       "metadata": {},
-      "source": [
-        "# Compare Queries and Performance"
-      ]
+      "source": "# Compare Queries and Performance"
     },
     {
       "cell_type": "markdown",
       "id": "2069ac4e-13a0-425a-b063-7434b339dd8e",
       "metadata": {},
-      "source": [
-        "**In-app analytics is everywhere.**\n",
-        "\n",
-        "<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/atlas-and-kai/images/in-app-analytics.png\" style=\"width: 600px; border: 1px solid darkorchid\">"
-      ]
+      "source": "**In-app analytics is everywhere.**\n\n<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/atlas-and-kai/images/in-app-analytics.png\" style=\"width: 600px; border: 1px solid darkorchid\">"
     },
     {
       "cell_type": "markdown",
       "id": "01f555e2-b809-4261-a8df-0669be80377c",
       "metadata": {},
-      "source": [
-        "## 4. Document counts"
-      ]
+      "source": "## 4. Document counts"
     },
     {
       "cell_type": "code",
@@ -238,59 +142,13 @@
       "id": "f1c54716-a4e9-49ae-9035-75a4c3761c90",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "num_iterations = 10\n",
-        "mongo_times = []\n",
-        "\n",
-        "for i in range(num_iterations):\n",
-        "    mg_start_time = time.time()\n",
-        "    mg_count = mongoitems.count_documents({})\n",
-        "    mg_stop_time = time.time()\n",
-        "    mongo_times.append(mg_stop_time - mg_start_time)\n",
-        "\n",
-        "s2_times = []\n",
-        "for i in range(num_iterations):\n",
-        "    s2_start_time = time.time()\n",
-        "    s2_count = s2mongoitems.count_documents({})\n",
-        "    s2_stop_time = time.time()\n",
-        "    s2_times.append(s2_stop_time - s2_start_time)\n",
-        "    \n",
-        "df = pd.DataFrame.from_dict({\n",
-        "    'iteration': list(range(1, num_iterations + 1)),\n",
-        "    'mongo_times': mongo_times,\n",
-        "    's2_times': s2_times,\n",
-        "})\n",
-        "\n",
-        "df_2 = pd.DataFrame.from_dict({\n",
-        "    'counts': [mg_count, s2_count],\n",
-        "    'connection_type': [\"mongodb\", \"singlestore\"],\n",
-        "})\n",
-        "\n",
-        "figures = [\n",
-        "    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']),\n",
-        "    px.bar(df_2, x=\"connection_type\", y=\"counts\", color=\"connection_type\")\n",
-        "]\n",
-        "\n",
-        "fig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Document Count Execution Time\",\"Document Counts\"])\n",
-        "for i, figure in enumerate(figures):\n",
-        "    for trace in range(len(figure[\"data\"])):\n",
-        "        fig.append_trace(figure[\"data\"][trace], row=1, col=i + 1)\n",
-        "        \n",
-        "fig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5,6,7,8,9,10], row=1, col=1)\n",
-        "\n",
-        "fig"
-      ]
+      "source": "num_iterations = 10\nmongo_times = []\n\nfor i in range(num_iterations):\n    mg_start_time = time.time()\n    mg_count = mongoitems.count_documents({})\n    mg_stop_time = time.time()\n    mongo_times.append(mg_stop_time - mg_start_time)\n\ns2_times = []\nfor i in range(num_iterations):\n    s2_start_time = time.time()\n    s2_count = s2mongoitems.count_documents({})\n    s2_stop_time = time.time()\n    s2_times.append(s2_stop_time - s2_start_time)\n    \ndf = pd.DataFrame.from_dict({\n    'iteration': list(range(1, num_iterations + 1)),\n    'mongo_times': mongo_times,\n    's2_times': s2_times,\n})\n\ndf_2 = pd.DataFrame.from_dict({\n    'counts': [mg_count, s2_count],\n    'connection_type': [\"mongodb\", \"singlestore\"],\n})\n\nfigures = [\n    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']),\n    px.bar(df_2, x=\"connection_type\", y=\"counts\", color=\"connection_type\")\n]\n\nfig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Document Count Execution Time\",\"Document Counts\"])\nfor i, figure in enumerate(figures):\n    for trace in range(len(figure[\"data\"])):\n        fig.append_trace(figure[\"data\"][trace], row=1, col=i + 1)\n        \nfig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5,6,7,8,9,10], row=1, col=1)\n\nfig"
     },
     {
       "cell_type": "markdown",
       "id": "94d4c502-fb66-45cb-a520-6ee39ae35476",
       "metadata": {},
-      "source": [
-        "## 5. Product Quantity Sold"
-      ]
+      "source": "## 5. Product Quantity Sold"
     },
     {
       "cell_type": "code",
@@ -298,68 +156,13 @@
       "id": "6de02fc3-fe7b-4dd4-a495-d0e785f4c58f",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "num_iterations = 10\n",
-        "mongo_times = []\n",
-        "\n",
-        "pipeline = [\n",
-        "    {\"$group\": {\"_id\": \"$item.name\", \"totalQuantity\": {\"$sum\": \"$item.quantity\"}}},\n",
-        "    {\"$sort\": {\"totalQuantity\": -1}},\n",
-        "    {\"$limit\": 5},\n",
-        "]\n",
-        "\n",
-        "for i in range(num_iterations):\n",
-        "    mg_start_time = time.time()\n",
-        "    mg_result = mongoitems.aggregate(pipeline)\n",
-        "    mg_stop_time = time.time()\n",
-        "    mongo_times.append(mg_stop_time - mg_start_time)\n",
-        "\n",
-        "s2_times = []\n",
-        "for i in range(num_iterations):\n",
-        "    s2_start_time = time.time()\n",
-        "    s2_result = s2mongoitems.aggregate(pipeline)\n",
-        "    s2_stop_time = time.time()\n",
-        "    s2_times.append(s2_stop_time - s2_start_time)\n",
-        "    \n",
-        "x_axis = list(range(1, num_iterations + 1))\n",
-        "data = {\n",
-        "    'iteration': x_axis,\n",
-        "    'mongo_times': mongo_times,\n",
-        "    's2_times': s2_times,\n",
-        "}    \n",
-        "df = pd.DataFrame.from_dict(data)\n",
-        "\n",
-        "item_names = [] \n",
-        "item_quantity = []\n",
-        "for i in mg_result:\n",
-        "    item_names.append(i[\"_id\"])\n",
-        "    item_quantity.append(i[\"totalQuantity\"])\n",
-        "\n",
-        "figures = [\n",
-        "    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']),\n",
-        "    px.bar(x=item_names, y=item_quantity)\n",
-        "]\n",
-        "\n",
-        "fig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Execution Time\",\"Comparison of Product Quantity Sold\"])\n",
-        "for i, figure in enumerate(figures):\n",
-        "    for trace in range(len(figure[\"data\"])):\n",
-        "        fig.append_trace(figure[\"data\"][trace], row=1, col=i+1)\n",
-        "        \n",
-        "fig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], row=1, col=1)\n",
-        "\n",
-        "fig"
-      ]
+      "source": "num_iterations = 10\nmongo_times = []\n\npipeline = [\n    {\"$group\": {\"_id\": \"$item.name\", \"totalQuantity\": {\"$sum\": \"$item.quantity\"}}},\n    {\"$sort\": {\"totalQuantity\": -1}},\n    {\"$limit\": 5},\n]\n\nfor i in range(num_iterations):\n    mg_start_time = time.time()\n    mg_result = mongoitems.aggregate(pipeline)\n    mg_stop_time = time.time()\n    mongo_times.append(mg_stop_time - mg_start_time)\n\ns2_times = []\nfor i in range(num_iterations):\n    s2_start_time = time.time()\n    s2_result = s2mongoitems.aggregate(pipeline)\n    s2_stop_time = time.time()\n    s2_times.append(s2_stop_time - s2_start_time)\n    \nx_axis = list(range(1, num_iterations + 1))\ndata = {\n    'iteration': x_axis,\n    'mongo_times': mongo_times,\n    's2_times': s2_times,\n}    \ndf = pd.DataFrame.from_dict(data)\n\nitem_names = [] \nitem_quantity = []\nfor i in mg_result:\n    item_names.append(i[\"_id\"])\n    item_quantity.append(i[\"totalQuantity\"])\n\nfigures = [\n    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']),\n    px.bar(x=item_names, y=item_quantity)\n]\n\nfig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Execution Time\",\"Comparison of Product Quantity Sold\"])\nfor i, figure in enumerate(figures):\n    for trace in range(len(figure[\"data\"])):\n        fig.append_trace(figure[\"data\"][trace], row=1, col=i+1)\n        \nfig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], row=1, col=1)\n\nfig"
     },
     {
       "cell_type": "markdown",
       "id": "9f11b18f-d414-4107-83a9-5d9d10172d6a",
       "metadata": {},
-      "source": [
-        "## 6. Average Customer Satisfaction"
-      ]
+      "source": "## 6. Average Customer Satisfaction"
     },
     {
       "cell_type": "code",
@@ -367,72 +170,13 @@
       "id": "c4bfc8e2-3f72-47be-b789-8f44a547ef60",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "num_iterations = 10\n",
-        "mongo_times = []\n",
-        "\n",
-        "pipeline = [\n",
-        "    {'$group': \n",
-        "         {\n",
-        "          '_id': '$customer.email', \n",
-        "          'average_satisfaction': {'$avg': '$customer.satisfaction'},\n",
-        "         },\n",
-        "    },\n",
-        "    {'$limit': 10},\n",
-        "]\n",
-        "\n",
-        "for i in range(num_iterations):\n",
-        "    mg_start_time = time.time()\n",
-        "    mg_result = mongotxs.aggregate(pipeline)\n",
-        "    mg_stop_time = time.time()\n",
-        "    mongo_times.append(mg_stop_time - mg_start_time)\n",
-        "\n",
-        "s2_times = []\n",
-        "for i in range(num_iterations):\n",
-        "    s2_start_time = time.time()\n",
-        "    s2_result = s2mongotxs.aggregate(pipeline)\n",
-        "    s2_stop_time = time.time()\n",
-        "    s2_times.append(s2_stop_time - s2_start_time)\n",
-        "    \n",
-        "x_axis = list(range(1, num_iterations + 1))\n",
-        "data = {\n",
-        "    'iteration': x_axis,\n",
-        "    'mongo_times': mongo_times,\n",
-        "    's2_times': s2_times,\n",
-        "}    \n",
-        "df = pd.DataFrame.from_dict(data)\n",
-        "\n",
-        "item_names = [] \n",
-        "item_quantity = []\n",
-        "for i in mg_result:\n",
-        "    item_names.append(i[\"_id\"])\n",
-        "    item_quantity.append(i[\"average_satisfaction\"])\n",
-        "\n",
-        "figures = [\n",
-        "    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']),\n",
-        "    px.bar(x=item_names, y=item_quantity)\n",
-        "]\n",
-        "\n",
-        "fig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Execution Time\",\"Average Customer Satisfaction\"])\n",
-        "for i, figure in enumerate(figures):\n",
-        "    for trace in range(len(figure[\"data\"])):\n",
-        "        fig.append_trace(figure[\"data\"][trace], row=1, col=i+1)\n",
-        "        \n",
-        "fig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], row=1, col=1)\n",
-        "\n",
-        "fig"
-      ]
+      "source": "num_iterations = 10\nmongo_times = []\n\npipeline = [\n    {'$group': \n         {\n          '_id': '$customer.email', \n          'average_satisfaction': {'$avg': '$customer.satisfaction'},\n         },\n    },\n    {'$limit': 10},\n]\n\nfor i in range(num_iterations):\n    mg_start_time = time.time()\n    mg_result = mongotxs.aggregate(pipeline)\n    mg_stop_time = time.time()\n    mongo_times.append(mg_stop_time - mg_start_time)\n\ns2_times = []\nfor i in range(num_iterations):\n    s2_start_time = time.time()\n    s2_result = s2mongotxs.aggregate(pipeline)\n    s2_stop_time = time.time()\n    s2_times.append(s2_stop_time - s2_start_time)\n    \nx_axis = list(range(1, num_iterations + 1))\ndata = {\n    'iteration': x_axis,\n    'mongo_times': mongo_times,\n    's2_times': s2_times,\n}    \ndf = pd.DataFrame.from_dict(data)\n\nitem_names = [] \nitem_quantity = []\nfor i in mg_result:\n    item_names.append(i[\"_id\"])\n    item_quantity.append(i[\"average_satisfaction\"])\n\nfigures = [\n    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']),\n    px.bar(x=item_names, y=item_quantity)\n]\n\nfig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Execution Time\",\"Average Customer Satisfaction\"])\nfor i, figure in enumerate(figures):\n    for trace in range(len(figure[\"data\"])):\n        fig.append_trace(figure[\"data\"][trace], row=1, col=i+1)\n        \nfig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], row=1, col=1)\n\nfig"
     },
     {
       "cell_type": "markdown",
       "id": "e6657ab9-551b-4d09-a1be-50a1b9091558",
       "metadata": {},
-      "source": [
-        "## 7. Average Satisfaction per Product"
-      ]
+      "source": "## 7. Average Satisfaction per Product"
     },
     {
       "cell_type": "code",
@@ -440,81 +184,13 @@
       "id": "8015fdd4-c6eb-437a-9d60-ee937817caf3",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "num_iterations = 10\n",
-        "mongo_times = []\n",
-        "\n",
-        "pipeline = [\n",
-        "    {\"$lookup\":\n",
-        "         {\n",
-        "          \"from\": \"txs\",\n",
-        "          \"localField\": \"tx_id\",\n",
-        "          \"foreignField\": \"transaction_id\",\n",
-        "          \"as\": \"transaction_links\",\n",
-        "         }\n",
-        "    },\n",
-        "    {\"$limit\": 10 },\n",
-        "    {\"$unwind\": \"$transaction_links\"},\n",
-        "    {\"$group\": \n",
-        "        {\n",
-        "         \"_id\": {\"item\": \"$item.name\"},\n",
-        "         \"Average Satisfaction\": {\"$avg\": \"$transaction_links.customer.satisfaction\"}\n",
-        "        }\n",
-        "    }\n",
-        "]\n",
-        "\n",
-        "for i in range(num_iterations):\n",
-        "    mg_start_time = time.time()\n",
-        "    mg_result = mongoitems.aggregate(pipeline)\n",
-        "    mg_stop_time = time.time()\n",
-        "    mongo_times.append(mg_stop_time - mg_start_time)\n",
-        "\n",
-        "s2_times = []\n",
-        "for i in range(num_iterations):\n",
-        "    s2_start_time = time.time()\n",
-        "    s2_result = s2mongoitems.aggregate(pipeline)\n",
-        "    s2_stop_time = time.time()\n",
-        "    s2_times.append(s2_stop_time - s2_start_time)\n",
-        "    \n",
-        "x_axis = list(range(1, num_iterations + 1))\n",
-        "data = {\n",
-        "    'iteration': x_axis,\n",
-        "    'mongo_times': mongo_times,\n",
-        "    's2_times': s2_times,\n",
-        "}    \n",
-        "df = pd.DataFrame.from_dict(data)\n",
-        "\n",
-        "item_names = [] \n",
-        "item_quantity = []\n",
-        "for i in mg_result:\n",
-        "    item_names.append(i[\"_id\"]['item'])\n",
-        "    item_quantity.append(i[\"Average Satisfaction\"])\n",
-        "    \n",
-        "figures = [\n",
-        "    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']),\n",
-        "    px.bar(x=item_names, y=item_quantity)\n",
-        "]\n",
-        "\n",
-        "fig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Execution Time\",\"Average Satisfaction per Product\"])\n",
-        "for i, figure in enumerate(figures):\n",
-        "    for trace in range(len(figure[\"data\"])):\n",
-        "        fig.append_trace(figure[\"data\"][trace], row=1, col=i+1)\n",
-        "        \n",
-        "fig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], row=1, col=1)\n",
-        "\n",
-        "fig"
-      ]
+      "source": "num_iterations = 10\nmongo_times = []\n\npipeline = [\n    {\"$lookup\":\n         {\n          \"from\": \"txs\",\n          \"localField\": \"tx_id\",\n          \"foreignField\": \"transaction_id\",\n          \"as\": \"transaction_links\",\n         }\n    },\n    {\"$limit\": 10 },\n    {\"$unwind\": \"$transaction_links\"},\n    {\"$group\": \n        {\n         \"_id\": {\"item\": \"$item.name\"},\n         \"Average Satisfaction\": {\"$avg\": \"$transaction_links.customer.satisfaction\"}\n        }\n    }\n]\n\nfor i in range(num_iterations):\n    mg_start_time = time.time()\n    mg_result = mongoitems.aggregate(pipeline)\n    mg_stop_time = time.time()\n    mongo_times.append(mg_stop_time - mg_start_time)\n\ns2_times = []\nfor i in range(num_iterations):\n    s2_start_time = time.time()\n    s2_result = s2mongoitems.aggregate(pipeline)\n    s2_stop_time = time.time()\n    s2_times.append(s2_stop_time - s2_start_time)\n    \nx_axis = list(range(1, num_iterations + 1))\ndata = {\n    'iteration': x_axis,\n    'mongo_times': mongo_times,\n    's2_times': s2_times,\n}    \ndf = pd.DataFrame.from_dict(data)\n\nitem_names = [] \nitem_quantity = []\nfor i in mg_result:\n    item_names.append(i[\"_id\"]['item'])\n    item_quantity.append(i[\"Average Satisfaction\"])\n    \nfigures = [\n    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']),\n    px.bar(x=item_names, y=item_quantity)\n]\n\nfig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Execution Time\",\"Average Satisfaction per Product\"])\nfor i, figure in enumerate(figures):\n    for trace in range(len(figure[\"data\"])):\n        fig.append_trace(figure[\"data\"][trace], row=1, col=i+1)\n        \nfig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], row=1, col=1)\n\nfig"
     },
     {
       "cell_type": "markdown",
       "id": "b14eb709-b58b-461e-b415-a4ca3461b1a6",
       "metadata": {},
-      "source": [
-        "## 8. Number of transactions by location and membership"
-      ]
+      "source": "## 8. Number of transactions by location and membership"
     },
     {
       "cell_type": "code",
@@ -522,84 +198,13 @@
       "id": "78abd324-cace-4ad6-abe7-d1b5d166a7e7",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "num_iterations = 10\n",
-        "mongo_times = []\n",
-        "\n",
-        "pipeline = [\n",
-        "    {\"$lookup\":\n",
-        "         {\n",
-        "          \"from\": \"custs\",\n",
-        "          \"localField\": \"customer.email\",\n",
-        "          \"foreignField\": \"email\",\n",
-        "          \"as\": \"transaction_links\",\n",
-        "         }\n",
-        "    },\n",
-        "    {\"$limit\": 100},\n",
-        "    {\"$group\": \n",
-        "        {\n",
-        "         \"_id\": {\n",
-        "                  \"location\": \"$store_location\",\n",
-        "                  \"membership\": \"$transaction_links.membership\"\n",
-        "                 },\n",
-        "         \"count\": {\"$sum\": 1}\n",
-        "        }\n",
-        "    },\n",
-        "    {\"$sort\": {\"count\":-1}}\n",
-        "]\n",
-        "for i in range (num_iterations):\n",
-        "    mg_start_time = time.time()\n",
-        "    mg_result = mongotxs.aggregate(pipeline)\n",
-        "    mg_stop_time = time.time()\n",
-        "    mongo_times.append(mg_stop_time - mg_start_time)\n",
-        "\n",
-        "s2_times = []\n",
-        "for i in range (num_iterations):\n",
-        "    s2_start_time = time.time()\n",
-        "    s2_result = s2mongotxs.aggregate(pipeline)\n",
-        "    s2_stop_time = time.time()\n",
-        "    s2_times.append(s2_stop_time - s2_start_time)\n",
-        "    \n",
-        "x_axis = list(range(1, num_iterations + 1))\n",
-        "data = {\n",
-        "    'iteration': x_axis,\n",
-        "    'mongo_times': mongo_times,\n",
-        "    's2_times': s2_times,\n",
-        "}\n",
-        "df = pd.DataFrame.from_dict(data)\n",
-        "\n",
-        "item_names = [] \n",
-        "item_quantity = []\n",
-        "for i in mg_result:\n",
-        "    toadd = i[\"_id\"]['location'] + ', ' + i[\"_id\"]['membership'][0]\n",
-        "    item_names.append(toadd)\n",
-        "    item_quantity.append(i['count'])\n",
-        "    \n",
-        "figures = [\n",
-        "    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']),\n",
-        "    px.bar(x=item_names, y=item_quantity)\n",
-        "]\n",
-        "\n",
-        "fig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Execution Time\",\"Sales per Store\"])\n",
-        "for i, figure in enumerate(figures):\n",
-        "    for trace in range(len(figure[\"data\"])):\n",
-        "        fig.append_trace(figure[\"data\"][trace], row=1, col=i+1)\n",
-        "\n",
-        "fig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], row=1, col=1)\n",
-        "\n",
-        "fig"
-      ]
+      "source": "num_iterations = 10\nmongo_times = []\n\npipeline = [\n    {\"$lookup\":\n         {\n          \"from\": \"custs\",\n          \"localField\": \"customer.email\",\n          \"foreignField\": \"email\",\n          \"as\": \"transaction_links\",\n         }\n    },\n    {\"$limit\": 100},\n    {\"$group\": \n        {\n         \"_id\": {\n                  \"location\": \"$store_location\",\n                  \"membership\": \"$transaction_links.membership\"\n                 },\n         \"count\": {\"$sum\": 1}\n        }\n    },\n    {\"$sort\": {\"count\":-1}}\n]\nfor i in range (num_iterations):\n    mg_start_time = time.time()\n    mg_result = mongotxs.aggregate(pipeline)\n    mg_stop_time = time.time()\n    mongo_times.append(mg_stop_time - mg_start_time)\n\ns2_times = []\nfor i in range (num_iterations):\n    s2_start_time = time.time()\n    s2_result = s2mongotxs.aggregate(pipeline)\n    s2_stop_time = time.time()\n    s2_times.append(s2_stop_time - s2_start_time)\n    \nx_axis = list(range(1, num_iterations + 1))\ndata = {\n    'iteration': x_axis,\n    'mongo_times': mongo_times,\n    's2_times': s2_times,\n}\ndf = pd.DataFrame.from_dict(data)\n\nitem_names = [] \nitem_quantity = []\nfor i in mg_result:\n    toadd = i[\"_id\"]['location'] + ', ' + i[\"_id\"]['membership'][0]\n    item_names.append(toadd)\n    item_quantity.append(i['count'])\n    \nfigures = [\n    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']),\n    px.bar(x=item_names, y=item_quantity)\n]\n\nfig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Execution Time\",\"Sales per Store\"])\nfor i, figure in enumerate(figures):\n    for trace in range(len(figure[\"data\"])):\n        fig.append_trace(figure[\"data\"][trace], row=1, col=i+1)\n\nfig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], row=1, col=1)\n\nfig"
     },
     {
       "cell_type": "markdown",
       "id": "83fa3e5c-975e-410c-a25e-4db2b8389952",
       "metadata": {},
-      "source": [
-        "## 9. Top 10 Product Sales"
-      ]
+      "source": "## 9. Top 10 Product Sales"
     },
     {
       "cell_type": "code",
@@ -607,81 +212,13 @@
       "id": "57a5a473-e840-4310-8f31-c53d9420a4cc",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "num_iterations = 10\n",
-        "mongo_times = []\n",
-        "pipeline = [\n",
-        "    {\"$project\": \n",
-        "        {\n",
-        "         \"item\": 1,\n",
-        "         \"revenue\": {\"$multiply\": [\"$item.price\", \"$item.quantity\"]}\n",
-        "        }\n",
-        "    },\n",
-        "    {\"$group\": \n",
-        "        {\n",
-        "         \"_id\": \"$item.name\",\n",
-        "         \"total_revenue\": {\"$sum\": \"$revenue\"}\n",
-        "        }\n",
-        "    },\n",
-        "    {\"$sort\": {\"total_revenue\": -1}},\n",
-        "    {\"$limit\": 10},\n",
-        "]\n",
-        "\n",
-        "for i in range (num_iterations):\n",
-        "    mg_start_time = time.time()\n",
-        "    mg_result = mongoitems.aggregate(pipeline)\n",
-        "    mg_stop_time = time.time()\n",
-        "    mongo_times.append(mg_stop_time - mg_start_time)\n",
-        "\n",
-        "s2_times = []\n",
-        "for i in range (num_iterations):\n",
-        "    s2_start_time = time.time()\n",
-        "    s2_result = s2mongoitems.aggregate(pipeline)\n",
-        "    s2_stop_time = time.time()\n",
-        "    s2_times.append(s2_stop_time - s2_start_time)\n",
-        "    \n",
-        "x_axis = [i + 1 for i in range(num_iterations)]\n",
-        "data = {\n",
-        "    'iteration': x_axis,\n",
-        "    'mongo_times': mongo_times,\n",
-        "    's2_times': s2_times,\n",
-        "}\n",
-        "df = pd.DataFrame.from_dict(data)\n",
-        "\n",
-        "item_names = [] \n",
-        "item_quantity = []\n",
-        "for i, result in enumerate(mg_result):\n",
-        "    if i >= 1:\n",
-        "        toadd = result[\"_id\"]\n",
-        "        item_names.append(toadd)\n",
-        "        item_quantity.append(result['total_revenue'])\n",
-        "\n",
-        "figures = [\n",
-        "    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']), # Exclude the first iteration from the line chart\n",
-        "    px.bar(x=item_names, y=item_quantity)\n",
-        "]\n",
-        "\n",
-        "fig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Execution Time\",\"Top 10 Product Sales\"])\n",
-        "for i, figure in enumerate(figures):\n",
-        "    for trace in range(len(figure[\"data\"])):\n",
-        "        fig.append_trace(figure[\"data\"][trace], row=1, col=i+1)\n",
-        "\n",
-        "fig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\n",
-        "fig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], row=1, col=1)\n",
-        "\n",
-        "fig"
-      ]
+      "source": "num_iterations = 10\nmongo_times = []\npipeline = [\n    {\"$project\": \n        {\n         \"item\": 1,\n         \"revenue\": {\"$multiply\": [\"$item.price\", \"$item.quantity\"]}\n        }\n    },\n    {\"$group\": \n        {\n         \"_id\": \"$item.name\",\n         \"total_revenue\": {\"$sum\": \"$revenue\"}\n        }\n    },\n    {\"$sort\": {\"total_revenue\": -1}},\n    {\"$limit\": 10},\n]\n\nfor i in range (num_iterations):\n    mg_start_time = time.time()\n    mg_result = mongoitems.aggregate(pipeline)\n    mg_stop_time = time.time()\n    mongo_times.append(mg_stop_time - mg_start_time)\n\ns2_times = []\nfor i in range (num_iterations):\n    s2_start_time = time.time()\n    s2_result = s2mongoitems.aggregate(pipeline)\n    s2_stop_time = time.time()\n    s2_times.append(s2_stop_time - s2_start_time)\n    \nx_axis = [i + 1 for i in range(num_iterations)]\ndata = {\n    'iteration': x_axis,\n    'mongo_times': mongo_times,\n    's2_times': s2_times,\n}\ndf = pd.DataFrame.from_dict(data)\n\nitem_names = [] \nitem_quantity = []\nfor i, result in enumerate(mg_result):\n    if i >= 1:\n        toadd = result[\"_id\"]\n        item_names.append(toadd)\n        item_quantity.append(result['total_revenue'])\n\nfigures = [\n    px.line(df.iloc[1:], x='iteration', y=['mongo_times', 's2_times']), # Exclude the first iteration from the line chart\n    px.bar(x=item_names, y=item_quantity)\n]\n\nfig = sp.make_subplots(rows=1, cols=2, subplot_titles=[\"Execution Time\",\"Top 10 Product Sales\"])\nfor i, figure in enumerate(figures):\n    for trace in range(len(figure[\"data\"])):\n        fig.append_trace(figure[\"data\"][trace], row=1, col=i+1)\n\nfig.update_yaxes(title_text=\"Time in Seconds\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(title_text=\"Iteration\", row=1, col=1)\nfig.update_xaxes(tickmode='array', tickvals=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], row=1, col=1)\n\nfig"
     },
     {
       "cell_type": "markdown",
       "id": "7434e7b2-8e62-4605-9666-622efaefd3d9",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -706,7 +243,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/getting-started-with-dataframes/notebook.ipynb
+++ b/notebooks/getting-started-with-dataframes/notebook.ipynb
@@ -4,17 +4,7 @@
       "cell_type": "markdown",
       "id": "caa4ce39-2f84-48b7-92b5-dccf6bede32b",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(235, 249, 245, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/browser.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Getting Started with DataFrames in SingleStoreDB</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(235, 249, 245, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/browser.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Getting Started with DataFrames in SingleStoreDB</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
@@ -54,9 +44,11 @@
       "cell_type": "code",
       "execution_count": null,
       "id": "944f4396-0fb6-4cc9-8a5c-fc7b9d450481",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": "%%sql\nDROP DATABASE IF EXISTS ibis_getting_started;\n\nCREATE DATABASE ibis_getting_started;"
+      "source": "DROP DATABASE IF EXISTS ibis_getting_started;\n\nCREATE DATABASE ibis_getting_started;"
     },
     {
       "cell_type": "markdown",
@@ -454,10 +446,7 @@
       "cell_type": "markdown",
       "id": "b40a7c86-2b36-4dad-a92f-d88f44410ec6",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -476,7 +465,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.10.9"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/getting-started-with-notebooks/notebook.ipynb
+++ b/notebooks/getting-started-with-notebooks/notebook.ipynb
@@ -4,64 +4,31 @@
       "cell_type": "markdown",
       "id": "a0efb393-2a46-4833-b5cf-8f048d9695b0",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(209, 153, 255, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/notes.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Getting Started with Notebooks</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(209, 153, 255, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/notes.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Getting Started with Notebooks</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "6d2bb122-3ae2-4eab-bbbd-3e3ba6907c4b",
       "metadata": {},
-      "source": [
-        "<table style=\"border: 0; border-spacing: 0; width: 100%; background-color: #03010D\"><tr>\n",
-        "    <td style=\"padding: 0; margin: 0; background-color: #03010D; width: 33%; text-align: center\"><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-vertical.png\" style=\"height: 200px;\"/></td>\n",
-        "    <td style=\"padding: 0; margin: 0; width: 66%; background-color: #03010D; text-align: right\"><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-jupyter.png\" style=\"height: 250px\"/></td>\n",
-        "</tr></table>"
-      ]
+      "source": "<table style=\"border: 0; border-spacing: 0; width: 100%; background-color: #03010D\"><tr>\n    <td style=\"padding: 0; margin: 0; background-color: #03010D; width: 33%; text-align: center\"><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-vertical.png\" style=\"height: 200px;\"/></td>\n    <td style=\"padding: 0; margin: 0; width: 66%; background-color: #03010D; text-align: right\"><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-jupyter.png\" style=\"height: 250px\"/></td>\n</tr></table>"
     },
     {
       "cell_type": "markdown",
       "id": "9e8e1c02-f723-4e0c-88f3-0adb4dc8b0de",
       "metadata": {},
-      "source": [
-        "## What you will learn in this notebook:\n",
-        "\n",
-        "1. Load a CSV file from our Github Repo [Python]\n",
-        "2. Ingest that file into a SingleStoreDB without defining the schema [Python]\n",
-        "3. Interact natively with the database using SQL [SQL]\n",
-        "4. Convert results to a DataFrame and visualize results with Plotly [Python]\n",
-        "\n",
-        "## Questions?\n",
-        "\n",
-        "Reach out to us through our [forum](https://www.singlestore.com/forum)."
-      ]
+      "source": "## What you will learn in this notebook:\n\n1. Load a CSV file from our Github Repo [Python]\n2. Ingest that file into a SingleStoreDB without defining the schema [Python]\n3. Interact natively with the database using SQL [SQL]\n4. Convert results to a DataFrame and visualize results with Plotly [Python]\n\n## Questions?\n\nReach out to us through our [forum](https://www.singlestore.com/forum)."
     },
     {
       "cell_type": "markdown",
       "id": "1b1d60b9-f1d9-4c8a-8d9d-ed8fc9968d40",
       "metadata": {},
-      "source": [
-        "## Enhance your notebooks with visualizations"
-      ]
+      "source": "## Enhance your notebooks with visualizations"
     },
     {
       "cell_type": "markdown",
       "id": "10234772-6625-4a4a-99af-f39e4e566c6d",
       "metadata": {},
-      "source": [
-        "## 1. Import libraries for reading data into a DataFrame\n",
-        "\n",
-        "Our data set contains geographic data, so we also install [Shapely](https://shapely.readthedocs.io/en/stable/) \n",
-        "to store that data in Shapely geometry objects."
-      ]
+      "source": "## 1. Import libraries for reading data into a DataFrame\n\nOur data set contains geographic data, so we also install [Shapely](https://shapely.readthedocs.io/en/stable/) \nto store that data in Shapely geometry objects."
     },
     {
       "cell_type": "code",
@@ -69,25 +36,13 @@
       "id": "fd26645f-c6b8-4853-baee-6bd77c6c1083",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip3 install shapely --quiet \n",
-        "\n",
-        "import pandas as pd\n",
-        "import shapely.wkt"
-      ]
+      "source": "!pip3 install shapely --quiet \n\nimport pandas as pd\nimport shapely.wkt"
     },
     {
       "cell_type": "markdown",
       "id": "ccb319b8-73b6-47ec-9dd0-ec33752fbb94",
       "metadata": {},
-      "source": [
-        "## 2. Load a csv file hosted in Github using Python\n",
-        "\n",
-        "Notice that we are using the `dtype=`, `parse_dates=`, and `converters=` options of the `read_csv` method to\n",
-        "convert specific columns into various data types, including geographic data in the `business_location` column.\n",
-        "See the [`read_csv`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html) documentation\n",
-        "for more information."
-      ]
+      "source": "## 2. Load a csv file hosted in Github using Python\n\nNotice that we are using the `dtype=`, `parse_dates=`, and `converters=` options of the `read_csv` method to\nconvert specific columns into various data types, including geographic data in the `business_location` column.\nSee the [`read_csv`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html) documentation\nfor more information."
     },
     {
       "cell_type": "code",
@@ -95,10 +50,7 @@
       "id": "cc892204-df0a-4c42-a772-7bf10d9f0e2d",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "url = 'https://raw.githubusercontent.com/singlestore-labs/singlestoredb-samples/main/' + \\\n",
-        "      'Sample%20datasets/csv/Restaurant_Scores_LIVES_Standard.csv'"
-      ]
+      "source": "url = 'https://raw.githubusercontent.com/singlestore-labs/singlestoredb-samples/main/' + \\\n      'Sample%20datasets/csv/Restaurant_Scores_LIVES_Standard.csv'"
     },
     {
       "cell_type": "code",
@@ -106,28 +58,13 @@
       "id": "5aec33ed-1b93-46f1-b9df-b6b726de1b82",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "def str_to_shapely(x: str) -> shapely.geometry.Point | None:\n",
-        "    \"\"\"Convert a WKT string to a shapely object while handling NULLs.\"\"\"\n",
-        "    return shapely.wkt.loads(x) if x else None\n",
-        "        \n",
-        "\n",
-        "# Read URL directly using pd.read_csv\n",
-        "df = pd.read_csv(url, index_col=0, \n",
-        "                 # Use parse_date=, dtype=, and converters= to specify explicit data types\n",
-        "                 parse_dates=['inspection_date'],\n",
-        "                 dtype=dict(business_id=int, business_phone_number=str, business_postal_code=str, inspection_score=float),\n",
-        "                 converters=dict(business_location=str_to_shapely))\n",
-        "df"
-      ]
+      "source": "def str_to_shapely(x: str) -> shapely.geometry.Point | None:\n    \"\"\"Convert a WKT string to a shapely object while handling NULLs.\"\"\"\n    return shapely.wkt.loads(x) if x else None\n        \n\n# Read URL directly using pd.read_csv\ndf = pd.read_csv(url, index_col=0, \n                 # Use parse_date=, dtype=, and converters= to specify explicit data types\n                 parse_dates=['inspection_date'],\n                 dtype=dict(business_id=int, business_phone_number=str, business_postal_code=str, inspection_score=float),\n                 converters=dict(business_location=str_to_shapely))\ndf"
     },
     {
       "cell_type": "markdown",
       "id": "07787fa4-445e-4452-a5de-8cf3b2dd2b34",
       "metadata": {},
-      "source": [
-        "Display the data types in the resulting DataFrame. Note that any objects that pandas does not support natively (e.g., strings, blobs, shapely geometries, etc.) show up as `object`."
-      ]
+      "source": "Display the data types in the resulting DataFrame. Note that any objects that pandas does not support natively (e.g., strings, blobs, shapely geometries, etc.) show up as `object`."
     },
     {
       "cell_type": "code",
@@ -135,36 +72,25 @@
       "id": "e3bf5b74-b0de-4cfb-b2ff-00b5934bc0a6",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "df.dtypes"
-      ]
+      "source": "df.dtypes"
     },
     {
       "cell_type": "markdown",
       "id": "4ceef3c0-c804-48c3-9ca0-dcb7f5abfe27",
       "metadata": {},
-      "source": [
-        "## 3. Ingest a DataFrame in a SingleStoreDB table"
-      ]
+      "source": "## 3. Ingest a DataFrame in a SingleStoreDB table"
     },
     {
       "cell_type": "markdown",
       "id": "66b9f526-3c1f-449f-93bb-c167b15fc598",
       "metadata": {},
-      "source": [
-        "1. Create the database\n",
-        "2. Import the library to connect to the database\n",
-        "3. Create the connection to the library\n",
-        "4. Ingest the dataframe to the newly created database"
-      ]
+      "source": "1. Create the database\n2. Import the library to connect to the database\n3. Create the connection to the library\n4. Ingest the dataframe to the newly created database"
     },
     {
       "cell_type": "markdown",
       "id": "ced28574-ac65-45bd-bed4-1df5273f9b57",
       "metadata": {},
-      "source": [
-        "Set the database name in a variable. It will be used in subsequent queries."
-      ]
+      "source": "Set the database name in a variable. It will be used in subsequent queries."
     },
     {
       "cell_type": "code",
@@ -172,54 +98,35 @@
       "id": "f0647bbb-dc4d-4852-89a9-f6b482808e88",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "database_name = 'getting_started_notebook'"
-      ]
+      "source": "database_name = 'getting_started_notebook'"
     },
     {
       "cell_type": "markdown",
       "id": "47e0bfb0-2006-4055-bdaf-081fd7473cf6",
       "metadata": {},
-      "source": [
-        "Here we are using the `database_name` variable in a `%%sql` cell. The syntax for including Python variables\n",
-        "is to surround the variable name with `{{ ... }}`."
-      ]
+      "source": "Here we are using the `database_name` variable in a SQL cell. The syntax for including Python variables\nis to surround the variable name with `{{ ... }}`."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "0790ee0d-f9e9-4952-b1ae-54f872e42aed",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE IF EXISTS {{database_name}};\n",
-        "\n",
-        "CREATE DATABASE {{database_name}};"
-      ]
+      "source": "DROP DATABASE IF EXISTS {{database_name}};\n\nCREATE DATABASE {{database_name}};"
     },
     {
       "cell_type": "markdown",
       "id": "b8f95d65-b3ca-4306-b22c-11f8eadcce13",
       "metadata": {},
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">    <b class=\"fa fa-solid fa-exclamation-circle\"></b>    <div>        <p><b>Action Required</b></p>        <p>Make sure to select the <tt>getting_started_notebook</tt> database from the drop-down menu at the top of this notebook.        It updates the <tt>connection_url</tt> which is used by the <tt>%%sql</tt> magic command and SQLAlchemy to make connections to the selected database.</p>    </div></div>"
-      ]
+      "source": "<div class=\"alert alert-block alert-warning\">    <b class=\"fa fa-solid fa-exclamation-circle\"></b>    <div>        <p><b>Action Required</b></p>        <p>Make sure to select the <tt>getting_started_notebook</tt> database from the drop-down menu at the top of this notebook.        It updates the <tt>connection_url</tt> which is used by SQLAlchemy to make connections to the selected database.</p>    </div></div>"
     },
     {
       "cell_type": "markdown",
       "id": "3a254b3c-f5c0-4ce5-9046-df97dbffd420",
       "metadata": {},
-      "source": [
-        "We can use SQLAlchemy and pandas to upload a DataFrame. Note that if the table does not exist, the data types will\n",
-        "be inferred from the data. This may not result in the exact types that you desire. You can define the table in\n",
-        "the database before uploading to get the exact types you want.\n",
-        "\n",
-        "If you get an error about the database not being selected, that simply means that your `connection_url` does not \n",
-        "contain a specific database to connect to. You can use the drop-down menu at the top of this notebook (immediately\n",
-        "under the title) to select a database to work with. Changing the selection in the drop-down menu also updates\n",
-        "the `connection_url` variable."
-      ]
+      "source": "We can use SQLAlchemy and pandas to upload a DataFrame. Note that if the table does not exist, the data types will\nbe inferred from the data. This may not result in the exact types that you desire. You can define the table in\nthe database before uploading to get the exact types you want.\n\nIf you get an error about the database not being selected, that simply means that your `connection_url` does not \ncontain a specific database to connect to. You can use the drop-down menu at the top of this notebook (immediately\nunder the title) to select a database to work with. Changing the selection in the drop-down menu also updates\nthe `connection_url` variable."
     },
     {
       "cell_type": "code",
@@ -227,22 +134,13 @@
       "id": "017b889a-5efe-4605-93a9-a80073b4b068",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import sqlalchemy as sa\n",
-        "\n",
-        "# Create a SQLAlchemy engine and connect\n",
-        "db_connection = sa.create_engine(connection_url).connect()"
-      ]
+      "source": "import sqlalchemy as sa\n\n# Create a SQLAlchemy engine and connect\ndb_connection = sa.create_engine(connection_url).connect()"
     },
     {
       "cell_type": "markdown",
       "id": "515fb529-745f-4005-a704-241dfe65e985",
       "metadata": {},
-      "source": [
-        "The SingleStoreDB Python package also adds a convenience function for SQLAlchemy connections\n",
-        "without using the `connection_url`. It automatically gets the connection information from \n",
-        "the `SINGLESTOREDB_URL` environment variable."
-      ]
+      "source": "The SingleStoreDB Python package also adds a convenience function for SQLAlchemy connections\nwithout using the `connection_url`. It automatically gets the connection information from \nthe `SINGLESTOREDB_URL` environment variable."
     },
     {
       "cell_type": "code",
@@ -250,83 +148,52 @@
       "id": "16f8f5df-6019-4fbb-9d4e-e1dd389ea7af",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import singlestoredb as s2\n",
-        "\n",
-        "# Create a SQLAlchemy engine and connect, without having to specify the connection URL\n",
-        "db_connection = s2.create_engine().connect()\n",
-        "\n",
-        "# Upload the DataFrame\n",
-        "df.to_sql('sf_restaurant_scores', con=db_connection, if_exists='append', chunksize=1000)"
-      ]
+      "source": "import singlestoredb as s2\n\n# Create a SQLAlchemy engine and connect, without having to specify the connection URL\ndb_connection = s2.create_engine().connect()\n\n# Upload the DataFrame\ndf.to_sql('sf_restaurant_scores', con=db_connection, if_exists='append', chunksize=1000)"
     },
     {
       "cell_type": "markdown",
       "id": "3e239229-b797-4b13-8cc6-1687e86328f5",
       "metadata": {},
-      "source": [
-        "## 4. Interact natively with the database using SQL"
-      ]
+      "source": "## 4. Interact natively with the database using SQL"
     },
     {
       "cell_type": "markdown",
       "id": "6bac215b-8d15-4e43-8492-f9483aa1970b",
       "metadata": {},
-      "source": [
-        "1. Read the top 10 rows from the table\n",
-        "2. Alter the table to get the date in a date format, not string\n",
-        "3. Read the number of restaurant inspections over the time in San Francisco "
-      ]
+      "source": "1. Read the top 10 rows from the table\n2. Alter the table to get the date in a date format, not string\n3. Read the number of restaurant inspections over the time in San Francisco "
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "c130a5a0-4b3d-42b5-849e-30aebd82f02a",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "SELECT * FROM {{database_name}}.sf_restaurant_scores LIMIT 10;"
-      ]
+      "source": "SELECT * FROM {{database_name}}.sf_restaurant_scores LIMIT 10;"
     },
     {
       "cell_type": "markdown",
       "id": "e30f3e37-6669-45d0-8859-72ddb466f65b",
       "metadata": {},
-      "source": [
-        "In the code block below, we use the `result1 <<` syntax on the `%%sql` line to store the result of the SQL\n",
-        "operation into a variable which can be used later. As with other Jupyter notebooks, you can always get the value\n",
-        "of the last executed cell in the `_` (underscore) variable, but setting a specifc variable name to use is generally\n",
-        "a safer way to retrieve results."
-      ]
+      "source": "In the code block below, we define the output variable `result1` to store the result of the SQL\noperation into a variable which can be used later. As with other Jupyter notebooks, you can always get the value\nof the last executed cell in the `_` (underscore) variable, but setting a specifc variable name to use is generally\na safer way to retrieve results."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "239813ff-7528-417c-b00f-7ccf274850e9",
-      "metadata": {},
+      "metadata": {
+        "language": "sql",
+        "output_variable": "result1"
+      },
       "outputs": [],
-      "source": [
-        "%%sql result1 <<\n",
-        "SELECT\n",
-        "    DATE_TRUNC('month', inspection_date) AS month,\n",
-        "    COUNT(*) AS count_inspection\n",
-        "FROM\n",
-        "    {{database_name}}.sf_restaurant_scores\n",
-        "GROUP BY\n",
-        "    MONTH\n",
-        "ORDER BY\n",
-        "    MONTH DESC;"
-      ]
+      "source": "SELECT\n    DATE_TRUNC('month', inspection_date) AS month,\n    COUNT(*) AS count_inspection\nFROM\n    {{database_name}}.sf_restaurant_scores\nGROUP BY\n    MONTH\nORDER BY\n    MONTH DESC;"
     },
     {
       "cell_type": "markdown",
       "id": "4dca22ec-028d-48fa-9cc1-e0723e05cfae",
       "metadata": {},
-      "source": [
-        "The output of a `%%sql` cell is a `ResultSet` which contains methods for converting to various other data types (e.g., `csv`, `dicts`, `DataFrame`, `PolarsDataFrame`). It is also possible to convert to a DataFrame by passing a `ResultSet` object to the DataFrame\n",
-        "constructor as we'll see below."
-      ]
+      "source": "The output of a SQL cell is a `ResultSet` which contains methods for converting to various other data types (e.g., `csv`, `dicts`, `DataFrame`, `PolarsDataFrame`). It is also possible to convert to a DataFrame by passing a `ResultSet` object to the DataFrame\nconstructor as we'll see below."
     },
     {
       "cell_type": "code",
@@ -334,26 +201,19 @@
       "id": "e34a2bde-82b7-4085-8e7c-64e72746bfc0",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "type(result1)"
-      ]
+      "source": "type(result1)"
     },
     {
       "cell_type": "markdown",
       "id": "0d26b14b-d6c9-4ab4-ba7d-5f029fa610e6",
       "metadata": {},
-      "source": [
-        "## 5. Visualize with Plotly"
-      ]
+      "source": "## 5. Visualize with Plotly"
     },
     {
       "cell_type": "markdown",
       "id": "8665a18d-f7d5-4da2-acc6-ea5a2a76d349",
       "metadata": {},
-      "source": [
-        "We are using [Plotly](https://plotly.com) to visualize the data in `result1`. The first parameter of the\n",
-        "`bar` function requires a DataFrame, so we'll convert `result1` to a DataFrame before calling `bar`."
-      ]
+      "source": "We are using [Plotly](https://plotly.com) to visualize the data in `result1`. The first parameter of the\n`bar` function requires a DataFrame, so we'll convert `result1` to a DataFrame before calling `bar`."
     },
     {
       "cell_type": "code",
@@ -361,10 +221,7 @@
       "id": "9f08d6ab-6895-4ec6-a115-f470d20354d1",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "result1_df = pd.DataFrame(result1)\n",
-        "result1_df[:5]"
-      ]
+      "source": "result1_df = pd.DataFrame(result1)\nresult1_df[:5]"
     },
     {
       "cell_type": "code",
@@ -372,39 +229,29 @@
       "id": "d849d710-bf6e-46db-ae25-f39b7854547e",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import plotly.express as px\n",
-        "\n",
-        "px.bar(result1_df, x=\"month\", y=\"count_inspection\", title=\"Inspections by Month\")"
-      ]
+      "source": "import plotly.express as px\n\npx.bar(result1_df, x=\"month\", y=\"count_inspection\", title=\"Inspections by Month\")"
     },
     {
       "cell_type": "markdown",
       "id": "93df4ad5-5fec-45d4-a051-24a651dbbff9",
       "metadata": {},
-      "source": [
-        "## 6. Cleanup database"
-      ]
+      "source": "## 6. Cleanup database"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "0792f4a6-82f4-413b-9895-cd4764f7a118",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE {{database_name}};"
-      ]
+      "source": "DROP DATABASE {{database_name}};"
     },
     {
       "cell_type": "markdown",
       "id": "ecc76eb3-7bd6-4efe-abcd-8989277daa2d",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -423,7 +270,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/hybrid-search/notebook.ipynb
+++ b/notebooks/hybrid-search/notebook.ipynb
@@ -4,42 +4,25 @@
       "cell_type": "markdown",
       "id": "505a207d-82ee-406d-bb92-e6a6900d6d18",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(209, 153, 255, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/vector-circle.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Hybrid Search</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(209, 153, 255, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/vector-circle.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Hybrid Search</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "f3a978dd",
       "metadata": {},
-      "source": []
+      "source": ""
     },
     {
       "cell_type": "markdown",
       "id": "d9f9e629-6eb9-4ca5-bcf2-1b8672b86725",
       "metadata": {},
-      "source": [
-        "*Source*: [OpenAI Cookbook](https://github.com/openai/openai-cookbook/blob/main/examples/data/AG_news_samples.csv)\n",
-        "\n",
-        "Hybrid search integrates both keyword-based search and semantic search in order to combine the strengths of both and provide users with a more comprehensive and efficient search experience. This notebook is an example on how to perform hybrid search with SingleStore's database and notebooks."
-      ]
+      "source": "*Source*: [OpenAI Cookbook](https://github.com/openai/openai-cookbook/blob/main/examples/data/AG_news_samples.csv)\n\nHybrid search integrates both keyword-based search and semantic search in order to combine the strengths of both and provide users with a more comprehensive and efficient search experience. This notebook is an example on how to perform hybrid search with SingleStore's database and notebooks."
     },
     {
       "cell_type": "markdown",
       "id": "532e8d3f-007d-48a4-8d36-44b561dd1109",
       "metadata": {},
-      "source": [
-        "## Setup\n",
-        "Let's first download the libraries necessary."
-      ]
+      "source": "## Setup\nLet's first download the libraries necessary."
     },
     {
       "cell_type": "code",
@@ -47,15 +30,7 @@
       "id": "07990b64-9447-46a8-abbc-51be1972dfda",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip install matplotlib --quiet\n",
-        "!pip install plotly.express --quiet\n",
-        "!pip install scikit-learn --quiet\n",
-        "!pip install tabulate --quiet\n",
-        "!pip install tiktoken --quiet\n",
-        "!pip install wget --quiet\n",
-        "!pip install openai --quiet"
-      ]
+      "source": "!pip install matplotlib --quiet\n!pip install plotly.express --quiet\n!pip install scikit-learn --quiet\n!pip install tabulate --quiet\n!pip install tiktoken --quiet\n!pip install wget --quiet\n!pip install openai --quiet"
     },
     {
       "cell_type": "code",
@@ -63,12 +38,7 @@
       "id": "a592dd5e-4114-4abf-923d-74038f5244eb",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import pandas as pd\n",
-        "import os\n",
-        "import wget\n",
-        "import json"
-      ]
+      "source": "import pandas as pd\nimport os\nimport wget\nimport json"
     },
     {
       "cell_type": "code",
@@ -76,23 +46,13 @@
       "id": "c2bffc74-4b6a-4c0f-acef-f72bb255ec79",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "# Import the library for vectorizing the data (Up to 2 minutes)\n",
-        "!pip install sentence-transformers --quiet\n",
-        "\n",
-        "from sentence_transformers import SentenceTransformer\n",
-        "\n",
-        "model = SentenceTransformer('flax-sentence-embeddings/all_datasets_v3_mpnet-base')"
-      ]
+      "source": "# Import the library for vectorizing the data (Up to 2 minutes)\n!pip install sentence-transformers --quiet\n\nfrom sentence_transformers import SentenceTransformer\n\nmodel = SentenceTransformer('flax-sentence-embeddings/all_datasets_v3_mpnet-base')"
     },
     {
       "cell_type": "markdown",
       "id": "0aa95a80-5683-4dc3-9e52-c3e890ab87af",
       "metadata": {},
-      "source": [
-        "## Import data from CSV file\n",
-        "This csv file holds the title, summary, and category of approximately 2000 news articles."
-      ]
+      "source": "## Import data from CSV file\nThis csv file holds the title, summary, and category of approximately 2000 news articles."
     },
     {
       "cell_type": "code",
@@ -100,17 +60,7 @@
       "id": "b1b2971e-d0f6-4cfa-a9a7-954602bda460",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "# download reviews csv file\n",
-        "cvs_file_path = \"https://raw.githubusercontent.com/openai/openai-cookbook/main/examples/data/AG_news_samples.csv\"\n",
-        "file_path = \"AG_news_samples.csv\"\n",
-        "\n",
-        "if not os.path.exists(file_path):\n",
-        "    wget.download(cvs_file_path, file_path)\n",
-        "    print(\"File downloaded successfully.\")\n",
-        "else:\n",
-        "    print(\"File already exists in the local file system.\")"
-      ]
+      "source": "# download reviews csv file\ncvs_file_path = \"https://raw.githubusercontent.com/openai/openai-cookbook/main/examples/data/AG_news_samples.csv\"\nfile_path = \"AG_news_samples.csv\"\n\nif not os.path.exists(file_path):\n    wget.download(cvs_file_path, file_path)\n    print(\"File downloaded successfully.\")\nelse:\n    print(\"File already exists in the local file system.\")"
     },
     {
       "cell_type": "code",
@@ -118,11 +68,7 @@
       "id": "4d08a1ea-59fb-4334-ba54-aa86119cbaea",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "df = pd.read_csv('AG_news_samples.csv')\n",
-        "df.pop('label_int')\n",
-        "df"
-      ]
+      "source": "df = pd.read_csv('AG_news_samples.csv')\ndf.pop('label_int')\ndf"
     },
     {
       "cell_type": "code",
@@ -130,25 +76,19 @@
       "id": "e30c69d3-a807-4437-84e9-6972e3bc3d85",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "data = df.values.tolist()"
-      ]
+      "source": "data = df.values.tolist()"
     },
     {
       "cell_type": "markdown",
       "id": "0b6c6560-bc60-43ba-93a4-1b4aee933d5b",
       "metadata": {},
-      "source": [
-        "## Set up the database"
-      ]
+      "source": "## Set up the database"
     },
     {
       "cell_type": "markdown",
       "id": "e1dd6296-54b0-4f8d-886a-13cacfc28163",
       "metadata": {},
-      "source": [
-        "Set up the SingleStoreDB database which will hold your data."
-      ]
+      "source": "Set up the SingleStoreDB database which will hold your data."
     },
     {
       "cell_type": "code",
@@ -156,26 +96,13 @@
       "id": "e1874b6f-706a-4638-ad2a-ca387953acaa",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE IF EXISTS news;\n",
-        "CREATE DATABASE IF NOT EXISTS news;"
-      ]
+      "source": "%%sql\nDROP DATABASE IF EXISTS news;\nCREATE DATABASE IF NOT EXISTS news;"
     },
     {
       "cell_type": "markdown",
       "id": "553f42af-0b29-4e11-a54b-9879447b2a27",
       "metadata": {},
-      "source": [
-        "<div class=\\\"alert alert-block alert-warning\\\" style=\"display: flex; background-color: rgba(255, 224, 177, 0.85); padding: 15px;\">   \n",
-        "    <b class=\\\"fa fa-solid fa-exclamation-circle\\\"></b>    \n",
-        "    <div>        \n",
-        "        <p><b>Action Required</b></p>        \n",
-        "        <p>Make sure to select the <tt>news</tt> database from the drop-down menu at the top of this notebook. It updates the <tt>connection_url</tt> which is used by the <tt>%%sql</tt> magic command and SQLAlchemy to make connections to the selected database.\n",
-        "        </p>    \n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div class=\\\"alert alert-block alert-warning\\\" style=\"display: flex; background-color: rgba(255, 224, 177, 0.85); padding: 15px;\">   \n    <b class=\\\"fa fa-solid fa-exclamation-circle\\\"></b>    \n    <div>        \n        <p><b>Action Required</b></p>        \n        <p>Make sure to select the <tt>news</tt> database from the drop-down menu at the top of this notebook. It updates the <tt>connection_url</tt> which is used by the <tt>%%sql</tt> magic command and SQLAlchemy to make connections to the selected database.\n        </p>    \n    </div>\n</div>"
     },
     {
       "cell_type": "code",
@@ -183,25 +110,13 @@
       "id": "3f1e2c3d-6fbd-46bb-9bd3-235eb51941cf",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP TABLE IF EXISTS news_articles;\n",
-        "CREATE TABLE IF NOT EXISTS news_articles (\n",
-        "    title TEXT,\n",
-        "    description TEXT,\n",
-        "    genre TEXT,\n",
-        "    embedding BLOB,\n",
-        "    FULLTEXT (title, description)\n",
-        ");"
-      ]
+      "source": "%%sql\nDROP TABLE IF EXISTS news_articles;\nCREATE TABLE IF NOT EXISTS news_articles (\n    title TEXT,\n    description TEXT,\n    genre TEXT,\n    embedding BLOB,\n    FULLTEXT (title, description)\n);"
     },
     {
       "cell_type": "markdown",
       "id": "d6a1952b-7313-4007-9ec5-4c506425190f",
       "metadata": {},
-      "source": [
-        "Connect to your SingleStoreDB Cloud workspaces using SQLAlchemy."
-      ]
+      "source": "Connect to your SingleStoreDB Cloud workspaces using SQLAlchemy."
     },
     {
       "cell_type": "code",
@@ -209,19 +124,13 @@
       "id": "1e8b918f-d849-4bad-b5e9-1cf8be138026",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "from singlestoredb import create_engine\n",
-        "\n",
-        "db_connection = create_engine().connect()"
-      ]
+      "source": "from singlestoredb import create_engine\n\ndb_connection = create_engine().connect()"
     },
     {
       "cell_type": "markdown",
       "id": "8bd97023-3d02-44d4-8bd3-59875cb22b6c",
       "metadata": {},
-      "source": [
-        "### Get embeddings for every row based on the description column"
-      ]
+      "source": "### Get embeddings for every row based on the description column"
     },
     {
       "cell_type": "code",
@@ -229,13 +138,7 @@
       "id": "496f84d0-51b6-4b66-bf5b-b1b260e4c2de",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "# Will take around 3.5 minutes to get embeddings for all 2000 columns\n",
-        "\n",
-        "descriptions = [row[1] for row in data]\n",
-        "all_embeddings = model.encode(descriptions)\n",
-        "all_embeddings.shape"
-      ]
+      "source": "# Will take around 3.5 minutes to get embeddings for all 2000 columns\n\ndescriptions = [row[1] for row in data]\nall_embeddings = model.encode(descriptions)\nall_embeddings.shape"
     },
     {
       "cell_type": "code",
@@ -243,17 +146,13 @@
       "id": "05b2f3fe-c35c-4252-b416-9f7b7aec60a6",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "combined_data = [tuple(row) + (embedding,) for embedding, row in zip(all_embeddings, data)]"
-      ]
+      "source": "combined_data = [tuple(row) + (embedding,) for embedding, row in zip(all_embeddings, data)]"
     },
     {
       "cell_type": "markdown",
       "id": "46b1628c-0ffc-4a84-ba8b-43e8df081b01",
       "metadata": {},
-      "source": [
-        "### Populate the database"
-      ]
+      "source": "### Populate the database"
     },
     {
       "cell_type": "code",
@@ -261,46 +160,19 @@
       "id": "cd3e5f9b-d9e5-45fe-ba20-4fb021d7a425",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%sql TRUNCATE TABLE news_articles;\n",
-        "\n",
-        "statement = '''\n",
-        "        INSERT INTO news.news_articles (\n",
-        "            title,\n",
-        "            description,\n",
-        "            genre,\n",
-        "            embedding\n",
-        "        )\n",
-        "        VALUES (\n",
-        "            %s,\n",
-        "            %s,\n",
-        "            %s,\n",
-        "            %s\n",
-        "        )\n",
-        "    '''\n",
-        "\n",
-        "for i, row in enumerate(combined_data):\n",
-        "    try:\n",
-        "        db_connection.execute(statement, row)\n",
-        "    except Exception as e:\n",
-        "        print(\"Error inserting row {}: {}\".format(i, e))"
-      ]
+      "source": "%sql TRUNCATE TABLE news_articles;\n\nstatement = '''\n        INSERT INTO news.news_articles (\n            title,\n            description,\n            genre,\n            embedding\n        )\n        VALUES (\n            %s,\n            %s,\n            %s,\n            %s\n        )\n    '''\n\nfor i, row in enumerate(combined_data):\n    try:\n        db_connection.execute(statement, row)\n    except Exception as e:\n        print(\"Error inserting row {}: {}\".format(i, e))"
     },
     {
       "cell_type": "markdown",
       "id": "a2f3d567-eaf4-487a-a1f9-2eb7e1071991",
       "metadata": {},
-      "source": [
-        "## Semantic search"
-      ]
+      "source": "## Semantic search"
     },
     {
       "cell_type": "markdown",
       "id": "7ad3b8f6-d3a8-4954-a737-f11c785ce9ce",
       "metadata": {},
-      "source": [
-        "### Connect to OpenAI"
-      ]
+      "source": "### Connect to OpenAI"
     },
     {
       "cell_type": "code",
@@ -308,13 +180,7 @@
       "id": "598d7077-d04c-46b3-b7c4-7b4362dd4507",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import openai\n",
-        "\n",
-        "# models\n",
-        "EMBEDDING_MODEL = \"text-embedding-ada-002\"\n",
-        "GPT_MODEL = \"gpt-3.5-turbo\""
-      ]
+      "source": "import openai\n\n# models\nEMBEDDING_MODEL = \"text-embedding-ada-002\"\nGPT_MODEL = \"gpt-3.5-turbo\""
     },
     {
       "cell_type": "code",
@@ -322,17 +188,13 @@
       "id": "9eea2f67-3c2e-4d1a-87c2-052c2acf4026",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "openai.api_key = 'YOUR_API_KEY_HERE'"
-      ]
+      "source": "openai.api_key = 'YOUR_API_KEY_HERE'"
     },
     {
       "cell_type": "markdown",
       "id": "6504f561-1ab1-4dbf-a523-0aef23b66e4b",
       "metadata": {},
-      "source": [
-        "### Run semantic search and get scores"
-      ]
+      "source": "### Run semantic search and get scores"
     },
     {
       "cell_type": "code",
@@ -340,44 +202,19 @@
       "id": "a62a4c06-d77a-49b1-beaf-4c54b04d001f",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "from openai.embeddings_utils import get_embedding\n",
-        "\n",
-        "search_query = \"Articles about Aussie captures\"\n",
-        "search_embedding = model.encode(search_query)\n",
-        "\n",
-        "# Create the SQL statement.\n",
-        "query_statement = \"\"\"\n",
-        "    SELECT\n",
-        "        title,\n",
-        "        description,\n",
-        "        genre,\n",
-        "        DOT_PRODUCT(embedding, %(embedding)s) AS score\n",
-        "    FROM news.news_articles\n",
-        "    ORDER BY score DESC\n",
-        "    LIMIT 10\n",
-        "    \"\"\"\n",
-        "\n",
-        "# Execute the SQL statement.\n",
-        "results = pd.DataFrame(db_connection.execute(query_statement, dict(embedding=search_embedding)))\n",
-        "results"
-      ]
+      "source": "from openai.embeddings_utils import get_embedding\n\nsearch_query = \"Articles about Aussie captures\"\nsearch_embedding = model.encode(search_query)\n\n# Create the SQL statement.\nquery_statement = \"\"\"\n    SELECT\n        title,\n        description,\n        genre,\n        DOT_PRODUCT(embedding, %(embedding)s) AS score\n    FROM news.news_articles\n    ORDER BY score DESC\n    LIMIT 10\n    \"\"\"\n\n# Execute the SQL statement.\nresults = pd.DataFrame(db_connection.execute(query_statement, dict(embedding=search_embedding)))\nresults"
     },
     {
       "cell_type": "markdown",
       "id": "2c8ff862-ea5b-4960-be5b-bcd530d6e918",
       "metadata": {},
-      "source": [
-        "## Hybrid search"
-      ]
+      "source": "## Hybrid search"
     },
     {
       "cell_type": "markdown",
       "id": "d0b2cff3-76f8-4a35-a596-4f001a9b4c8c",
       "metadata": {},
-      "source": [
-        "This search finds the average of the score gotten from the semantic search and the score gotten from the key-word search and sorts the news articles by this combined score to perform an effective hybrid search."
-      ]
+      "source": "This search finds the average of the score gotten from the semantic search and the score gotten from the key-word search and sorts the news articles by this combined score to perform an effective hybrid search."
     },
     {
       "cell_type": "code",
@@ -385,37 +222,13 @@
       "id": "9df7073f-6a89-4528-968c-7d5c21876a83",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "hyb_query = \"Articles about Aussie captures\"\n",
-        "hyb_embedding = model.encode(hyb_query)\n",
-        "\n",
-        "# Create the SQL statement.\n",
-        "hyb_statement = \"\"\"\n",
-        "    SELECT\n",
-        "        title,\n",
-        "        description,\n",
-        "        genre,\n",
-        "        DOT_PRODUCT(embedding, %(embedding)s) AS semantic_score,\n",
-        "        MATCH(title, description) AGAINST (%(query)s) AS keyword_score,\n",
-        "        (semantic_score + keyword_score) / 2 AS combined_score\n",
-        "    FROM news.news_articles\n",
-        "    ORDER BY combined_score DESC\n",
-        "    LIMIT 10\n",
-        "    \"\"\"\n",
-        "\n",
-        "# Execute the SQL statement.\n",
-        "hyb_results = pd.DataFrame(db_connection.execute(hyb_statement, dict(embedding=hyb_embedding, query=hyb_query)))\n",
-        "hyb_results"
-      ]
+      "source": "hyb_query = \"Articles about Aussie captures\"\nhyb_embedding = model.encode(hyb_query)\n\n# Create the SQL statement.\nhyb_statement = \"\"\"\n    SELECT\n        title,\n        description,\n        genre,\n        DOT_PRODUCT(embedding, %(embedding)s) AS semantic_score,\n        MATCH(title, description) AGAINST (%(query)s) AS keyword_score,\n        (semantic_score + keyword_score) / 2 AS combined_score\n    FROM news.news_articles\n    ORDER BY combined_score DESC\n    LIMIT 10\n    \"\"\"\n\n# Execute the SQL statement.\nhyb_results = pd.DataFrame(db_connection.execute(hyb_statement, dict(embedding=hyb_embedding, query=hyb_query)))\nhyb_results"
     },
     {
       "cell_type": "markdown",
       "id": "f9f6e53b-fb02-4d1a-908f-b96d1c2cdfd0",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -440,7 +253,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/image-matching-with-sql/notebook.ipynb
+++ b/notebooks/image-matching-with-sql/notebook.ipynb
@@ -10,7 +10,7 @@
       "cell_type": "markdown",
       "id": "7b2bd61f-bdc4-4aef-9ab3-feeb8a0138d3",
       "metadata": {},
-      "source": "**SingleStoreDB can supercharge your apps with AI!**\n\nIn this notebook, we\u2019ll demonstrate how we use the [`dot_product`](https://docs.singlestore.com/db/v8.1/en/reference/sql-reference/vector-functions/dot_product.html) function (for cosine similarity) to find a matching image of a celebrity from among 7 thousand records in just 3 milliseconds!\n\nEfficient retrieval of high-dimensional vectors and handling of large-scale vector similarity matching workloads are made possible by SingleStore’s distributed architecture and efficient low-level execution. SingleStoreDB powers many AI applications including face matching, product photo matching, object recognition, text similarity matching, and sentiment analysis. "
+      "source": "**SingleStoreDB can supercharge your apps with AI!**\n\nIn this notebook, we\u2019ll demonstrate how we use the [`dot_product`](https://docs.singlestore.com/db/v8.1/en/reference/sql-reference/vector-functions/dot_product.html) function (for cosine similarity) to find a matching image of a celebrity from among 7 thousand records in just 3 milliseconds!\n\nEfficient retrieval of high-dimensional vectors and handling of large-scale vector similarity matching workloads are made possible by SingleStore\u2019s distributed architecture and efficient low-level execution. SingleStoreDB powers many AI applications including face matching, product photo matching, object recognition, text similarity matching, and sentiment analysis. "
     },
     {
       "cell_type": "markdown",

--- a/notebooks/image-matching-with-sql/notebook.ipynb
+++ b/notebooks/image-matching-with-sql/notebook.ipynb
@@ -4,96 +4,47 @@
       "cell_type": "markdown",
       "id": "dff08daa-d4e7-4816-b8de-be40c86ec2b9",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(209, 153, 255, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/face-viewfinder.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Image Matching with SQL</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(209, 153, 255, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/face-viewfinder.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Image Matching with SQL</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "7b2bd61f-bdc4-4aef-9ab3-feeb8a0138d3",
       "metadata": {},
-      "source": [
-        "**SingleStoreDB can supercharge your apps with AI!**\n",
-        "\n",
-        "In this notebook, we\u2019ll demonstrate how we use the [`dot_product`](https://docs.singlestore.com/db/v8.1/en/reference/sql-reference/vector-functions/dot_product.html) function (for cosine similarity) to find a matching image of a celebrity from among 7 thousand records in just 3 milliseconds!\n",
-        "\n",
-        "Efficient retrieval of high-dimensional vectors and handling of large-scale vector similarity matching workloads are made possible by SingleStore\u2019s distributed architecture and efficient low-level execution. SingleStoreDB powers many AI applications including face matching, product photo matching, object recognition, text similarity matching, and sentiment analysis. "
-      ]
+      "source": "**SingleStoreDB can supercharge your apps with AI!**\n\nIn this notebook, we\u2019ll demonstrate how we use the [`dot_product`](https://docs.singlestore.com/db/v8.1/en/reference/sql-reference/vector-functions/dot_product.html) function (for cosine similarity) to find a matching image of a celebrity from among 7 thousand records in just 3 milliseconds!\n\nEfficient retrieval of high-dimensional vectors and handling of large-scale vector similarity matching workloads are made possible by SingleStore’s distributed architecture and efficient low-level execution. SingleStoreDB powers many AI applications including face matching, product photo matching, object recognition, text similarity matching, and sentiment analysis. "
     },
     {
       "cell_type": "markdown",
       "id": "b21735c2-31ad-4e38-9a5f-afae2c46de38",
       "metadata": {},
-      "source": [
-        "<div style=\"text-align: center\">\n",
-        "<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/image-matching-with-sql/images/emma-thompson.png\" width=\"500\"/>\n",
-        "</div>"
-      ]
+      "source": "<div style=\"text-align: center\">\n<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/image-matching-with-sql/images/emma-thompson.png\" width=\"500\"/>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "facd7889-eaed-44f8-ba7c-ac852c26e9f3",
       "metadata": {},
-      "source": [
-        "## 1. Create a workspace in your workspace group\n",
-        "\n",
-        "S-00 is sufficient.\n",
-        "\n",
-        "## 2. Create a Database named image_recognition\n",
-        "\n",
-        "The code below will drop the current `image_recognition` database and create a fresh one."
-      ]
+      "source": "## 1. Create a workspace in your workspace group\n\nS-00 is sufficient.\n\n## 2. Create a Database named image_recognition\n\nThe code below will drop the current `image_recognition` database and create a fresh one."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "0ee1fb52-14ee-48cc-880c-d525a7d84988",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE IF EXISTS image_recognition;\n",
-        "\n",
-        "CREATE DATABASE image_recognition;"
-      ]
+      "source": "DROP DATABASE IF EXISTS image_recognition;\n\nCREATE DATABASE image_recognition;"
     },
     {
       "cell_type": "markdown",
       "id": "899100f0-bac6-4e56-a1e3-eaf5ba32d345",
       "metadata": {},
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n",
-        "    <div>\n",
-        "        <p><b>Action Required</b></p>\n",
-        "        <p>Make sure to select the <tt>image_recognition</tt> database from the drop-down menu at the top of this notebook.\n",
-        "        It updates the <tt>connection_url</tt> which is used by the <tt>%%sql</tt> magic command and SQLAlchemy to make connections to the selected database.</p>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div class=\"alert alert-block alert-warning\">\n    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n    <div>\n        <p><b>Action Required</b></p>\n        <p>Make sure to select the <tt>image_recognition</tt> database from the drop-down menu at the top of this notebook.\n        It updates the <tt>connection_url</tt> which is used by SQLAlchemy to make connections to the selected database.</p>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "278053e8-7457-4655-a6fe-5c95ecb361de",
       "metadata": {},
-      "source": [
-        "## 3. Install and import the following libraries\n",
-        "\n",
-        "This will take approximately 40 seconds. We are using the `--quiet` option of `pip` here to keep\n",
-        "the log messages from filling the output. You can remove that option if you want to see\n",
-        "the installation process. \n",
-        "\n",
-        "You may see messages printed about not being able to find cuda drivers or TensorRT. These can\n",
-        "be ignored."
-      ]
+      "source": "## 3. Install and import the following libraries\n\nThis will take approximately 40 seconds. We are using the `--quiet` option of `pip` here to keep\nthe log messages from filling the output. You can remove that option if you want to see\nthe installation process. \n\nYou may see messages printed about not being able to find cuda drivers or TensorRT. These can\nbe ignored."
     },
     {
       "cell_type": "code",
@@ -101,70 +52,29 @@
       "id": "4a58d896-5ea9-4335-8cfe-18de418ba2de",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip3 install boto3 matplotlib tensorflow opencv-python-headless --quiet\n",
-        "\n",
-        "import json\n",
-        "import os\n",
-        "import random\n",
-        "import urllib.request\n",
-        "\n",
-        "import boto3\n",
-        "import cv2\n",
-        "import botocore.exceptions\n",
-        "import ipywidgets as widgets\n",
-        "import tensorflow.compat.v1 as tf\n",
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "import requests\n",
-        "import singlestoredb as s2\n",
-        "import tensorflow.compat.v1 as tf\n",
-        "from botocore import UNSIGNED\n",
-        "from botocore.client import Config\n",
-        "\n",
-        "tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)\n",
-        "tf.disable_v2_behavior()"
-      ]
+      "source": "!pip3 install boto3 matplotlib tensorflow opencv-python-headless --quiet\n\nimport json\nimport os\nimport random\nimport urllib.request\n\nimport boto3\nimport cv2\nimport botocore.exceptions\nimport ipywidgets as widgets\nimport tensorflow.compat.v1 as tf\nimport matplotlib.pyplot as plt\nimport numpy as np\nimport pandas as pd\nimport requests\nimport singlestoredb as s2\nimport tensorflow.compat.v1 as tf\nfrom botocore import UNSIGNED\nfrom botocore.client import Config\n\ntf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)\ntf.disable_v2_behavior()"
     },
     {
       "cell_type": "markdown",
       "id": "3bb47d4f-d54d-4fcc-835e-6a5066fa84bc",
       "metadata": {},
-      "source": [
-        "## 4. Create a table of images of people\n",
-        "\n",
-        "The table will contain two columns: 1) the filename containing the image and 2) the vector embedding\n",
-        "of the image as a blob containing an array of 32-bit floats."
-      ]
+      "source": "## 4. Create a table of images of people\n\nThe table will contain two columns: 1) the filename containing the image and 2) the vector embedding\nof the image as a blob containing an array of 32-bit floats."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "b115b516-df6d-4100-aacc-c49c50a91819",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "CREATE TABLE people (\n",
-        "    filename VARCHAR(255), \n",
-        "    vector BLOB, \n",
-        "    SHARD(filename)\n",
-        ");"
-      ]
+      "source": "CREATE TABLE people (\n    filename VARCHAR(255), \n    vector BLOB, \n    SHARD(filename)\n);"
     },
     {
       "cell_type": "markdown",
       "id": "41a990db-9e11-48e3-8011-8bd9770a27a2",
       "metadata": {},
-      "source": [
-        "## 5. Import our sample dataset into the table\n",
-        "\n",
-        "**This dataset has 7000 vector embeddings of celebrities!**\n",
-        "\n",
-        "Note that we are using the `converters=` parameter of `pd.read_csv` to parse the text as a JSON array and convert it\n",
-        "to a numpy array for the resulting DataFrame column."
-      ]
+      "source": "## 5. Import our sample dataset into the table\n\n**This dataset has 7000 vector embeddings of celebrities!**\n\nNote that we are using the `converters=` parameter of `pd.read_csv` to parse the text as a JSON array and convert it\nto a numpy array for the resulting DataFrame column."
     },
     {
       "cell_type": "code",
@@ -172,10 +82,7 @@
       "id": "d1fb9284-f64e-49c3-acf8-d01f7a0d7e81",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "url = 'https://raw.githubusercontent.com/singlestore-labs/singlestoredb-samples/main/' + \\\n",
-        "      'Tutorials/Face%20matching/celebrity_data.sql'"
-      ]
+      "source": "url = 'https://raw.githubusercontent.com/singlestore-labs/singlestoredb-samples/main/' + \\\n      'Tutorials/Face%20matching/celebrity_data.sql'"
     },
     {
       "cell_type": "code",
@@ -183,56 +90,29 @@
       "id": "5fe33107-3e46-49f8-9450-4cac14501a34",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "def json_to_numpy_array(x: str | None) -> np.ndarray | None:\n",
-        "    \"\"\"Convert JSON array string to numpy array.\"\"\"\n",
-        "    return np.array(json.loads(x), dtype='f4') if x else None\n",
-        "\n",
-        "\n",
-        "# Read data into DataFrame\n",
-        "df = pd.read_csv(url, sep='\"', usecols=[1, 3], names=['filename', 'vector'], \n",
-        "                 converters=dict(vector=json_to_numpy_array))\n",
-        "\n",
-        "# Create database connection\n",
-        "db_connection = s2.create_engine().connect()\n",
-        "\n",
-        "# Upload DataFrame\n",
-        "df.to_sql('people', con=db_connection, index=False, if_exists='append')"
-      ]
+      "source": "def json_to_numpy_array(x: str | None) -> np.ndarray | None:\n    \"\"\"Convert JSON array string to numpy array.\"\"\"\n    return np.array(json.loads(x), dtype='f4') if x else None\n\n\n# Read data into DataFrame\ndf = pd.read_csv(url, sep='\"', usecols=[1, 3], names=['filename', 'vector'], \n                 converters=dict(vector=json_to_numpy_array))\n\n# Create database connection\ndb_connection = s2.create_engine().connect()\n\n# Upload DataFrame\ndf.to_sql('people', con=db_connection, index=False, if_exists='append')"
     },
     {
       "cell_type": "markdown",
       "id": "168be056-17da-4f94-8252-3e5d79459a8b",
       "metadata": {},
-      "source": [
-        "## 6. Run our image matching algorithm using just 2 lines of SQL\n",
-        "\n",
-        "In this example, we use an image of Adam Sandler and find the 5 closest images in our database to it. We use the `dot_product` function to measure cosine_similarity of each vector in the database to the input image. "
-      ]
+      "source": "## 6. Run our image matching algorithm using just 2 lines of SQL\n\nIn this example, we use an image of Adam Sandler and find the 5 closest images in our database to it. We use the `dot_product` function to measure cosine_similarity of each vector in the database to the input image. "
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "b26fd8fe-a90d-47c5-9cd1-63def15e2eac",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "SET @v = (SELECT vector FROM people WHERE filename = \"Adam_Sandler/Adam_Sandler_0003.jpg\");\n",
-        "SELECT filename, DOT_PRODUCT(vector, @v) AS score FROM people ORDER BY score DESC LIMIT 5;"
-      ]
+      "source": "SET @v = (SELECT vector FROM people WHERE filename = \"Adam_Sandler/Adam_Sandler_0003.jpg\");\nSELECT filename, DOT_PRODUCT(vector, @v) AS score FROM people ORDER BY score DESC LIMIT 5;"
     },
     {
       "cell_type": "markdown",
       "id": "1d0606a8-6503-4522-8a85-6366263e4b5e",
       "metadata": {},
-      "source": [
-        "## 7. Pick an image of a celebrity and see which images matched closest to it!\n",
-        "\n",
-        "1. Run the code cell\n",
-        "2. Pick a celebrity picture\n",
-        "3. Wait for the match!"
-      ]
+      "source": "## 7. Pick an image of a celebrity and see which images matched closest to it!\n\n1. Run the code cell\n2. Pick a celebrity picture\n3. Wait for the match!"
     },
     {
       "cell_type": "code",
@@ -240,96 +120,13 @@
       "id": "6b4d75e4-38b5-491d-a77c-35f949ef4ca4",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "s3 = boto3.resource('s3', region_name='us-east-1', config=Config(signature_version=UNSIGNED))\n",
-        "bucket = s3.Bucket('studiotutorials')\n",
-        "prefix = 'face_matching/'\n",
-        "\n",
-        "peoplenames = %sql SELECT filename FROM people ORDER BY filename;\n",
-        "\n",
-        "names = [x[0] for x in peoplenames]\n",
-        "\n",
-        "out = widgets.Output(layout={'border': '1px solid black'})\n",
-        "\n",
-        "def on_value_change(change: widgets.Output) -> None:\n",
-        "    \"\"\"Handle a value change event on a drop-down menu.\"\"\"\n",
-        "    with out:\n",
-        "        out.clear_output();\n",
-        "        selected_name = change.new\n",
-        "        countdb = %sql SELECT COUNT(*) FROM people WHERE filename = '{{selected_name}}';\n",
-        "        \n",
-        "        if int(countdb[-1][0]) > 0: \n",
-        "            %sql SET @v = (SELECT vector FROM people WHERE filename = '{{selected_name}}');\n",
-        "            result = %sql SELECT filename, DOT_PRODUCT(vector, @v) AS score FROM people ORDER BY score DESC LIMIT 5;\n",
-        "            original = \"original.jpg\"\n",
-        "            images = []\n",
-        "            matches = []\n",
-        "            try:\n",
-        "                bucket.download_file(prefix + selected_name, original)\n",
-        "                images.append(original)\n",
-        "            except botocore.exceptions.ClientError as e:\n",
-        "                if e.response['Error']['Code'] == \"404\":\n",
-        "                    bucket.download_file(prefix + \"error.jpg\", original)\n",
-        "                else:\n",
-        "                    raise\n",
-        "            cnt = 0\n",
-        "            for res in result:\n",
-        "                print(res)\n",
-        "                temp_file = \"match\" + str(cnt) + \".jpg\"\n",
-        "                images.append(temp_file)\n",
-        "                matches.append(res[1])\n",
-        "                try:\n",
-        "                    bucket.download_file(prefix + res[0], temp_file)\n",
-        "                except botocore.exceptions.ClientError as e:\n",
-        "                    if e.response['Error']['Code'] == \"404\":\n",
-        "                        bucket.download_file(prefix + \"error.jpg\", temp_file)\n",
-        "                    else:\n",
-        "                        raise\n",
-        "                cnt += 1\n",
-        "            fig, axes = plt.subplots(nrows=1, ncols=6, figsize=(40, 40))\n",
-        "            for i in range(6):\n",
-        "                axes[i].imshow(plt.imread(images[i]))\n",
-        "                axes[i].set_xticks([])\n",
-        "                axes[i].set_yticks([])\n",
-        "                axes[i].set_xlabel('')\n",
-        "                axes[i].set_ylabel('')\n",
-        "                if i == 0:\n",
-        "                  axes[i].set_title(\"Original Image\", fontsize=14)\n",
-        "                else:\n",
-        "                  axes[i].set_title(\"Match \" + str(i) + \". Score: \" + str(matches[i-1]), fontsize=14)\n",
-        "            plt.show()\n",
-        "        else:\n",
-        "              print(\"No match for this image as it was not inserted into the People Table\")\n",
-        "\n",
-        "dropdown = widgets.Dropdown(\n",
-        "    options=names,\n",
-        "    description='Select an Image:',\n",
-        "    placeholder='Select an Image!',\n",
-        "    style={'description_width': 'initial'},\n",
-        "    layout={'width': 'max-content'}\n",
-        ")\n",
-        "\n",
-        "display(dropdown)\n",
-        "dropdown.observe(on_value_change, names='value')\n",
-        "display(out)"
-      ]
+      "source": "s3 = boto3.resource('s3', region_name='us-east-1', config=Config(signature_version=UNSIGNED))\nbucket = s3.Bucket('studiotutorials')\nprefix = 'face_matching/'\n\npeoplenames = %sql SELECT filename FROM people ORDER BY filename;\n\nnames = [x[0] for x in peoplenames]\n\nout = widgets.Output(layout={'border': '1px solid black'})\n\ndef on_value_change(change: widgets.Output) -> None:\n    \"\"\"Handle a value change event on a drop-down menu.\"\"\"\n    with out:\n        out.clear_output();\n        selected_name = change.new\n        countdb = %sql SELECT COUNT(*) FROM people WHERE filename = '{{selected_name}}';\n        \n        if int(countdb[-1][0]) > 0: \n            %sql SET @v = (SELECT vector FROM people WHERE filename = '{{selected_name}}');\n            result = %sql SELECT filename, DOT_PRODUCT(vector, @v) AS score FROM people ORDER BY score DESC LIMIT 5;\n            original = \"original.jpg\"\n            images = []\n            matches = []\n            try:\n                bucket.download_file(prefix + selected_name, original)\n                images.append(original)\n            except botocore.exceptions.ClientError as e:\n                if e.response['Error']['Code'] == \"404\":\n                    bucket.download_file(prefix + \"error.jpg\", original)\n                else:\n                    raise\n            cnt = 0\n            for res in result:\n                print(res)\n                temp_file = \"match\" + str(cnt) + \".jpg\"\n                images.append(temp_file)\n                matches.append(res[1])\n                try:\n                    bucket.download_file(prefix + res[0], temp_file)\n                except botocore.exceptions.ClientError as e:\n                    if e.response['Error']['Code'] == \"404\":\n                        bucket.download_file(prefix + \"error.jpg\", temp_file)\n                    else:\n                        raise\n                cnt += 1\n            fig, axes = plt.subplots(nrows=1, ncols=6, figsize=(40, 40))\n            for i in range(6):\n                axes[i].imshow(plt.imread(images[i]))\n                axes[i].set_xticks([])\n                axes[i].set_yticks([])\n                axes[i].set_xlabel('')\n                axes[i].set_ylabel('')\n                if i == 0:\n                  axes[i].set_title(\"Original Image\", fontsize=14)\n                else:\n                  axes[i].set_title(\"Match \" + str(i) + \". Score: \" + str(matches[i-1]), fontsize=14)\n            plt.show()\n        else:\n              print(\"No match for this image as it was not inserted into the People Table\")\n\ndropdown = widgets.Dropdown(\n    options=names,\n    description='Select an Image:',\n    placeholder='Select an Image!',\n    style={'description_width': 'initial'},\n    layout={'width': 'max-content'}\n)\n\ndisplay(dropdown)\ndropdown.observe(on_value_change, names='value')\ndisplay(out)"
     },
     {
       "cell_type": "markdown",
       "id": "cea04465-6a69-42f1-8249-4c49488506f6",
       "metadata": {},
-      "source": [
-        "## 8. See which celebrity you look most like! \n",
-        "\n",
-        "In this step, you'll need to upload a picture of yourself.\n",
-        "Note that your image MUST be at least 160x160 pixels. Head-shots and zoomed-in photos work better as we don't preprocess the image to just isolate the facial context! We only have 7,000 pictures so matching might be limited.\n",
-        "\n",
-        "1. Run the code cell\n",
-        "2. Upload your picture\n",
-        "3. Wait for the match!\n",
-        "\n",
-        "**A low score for matching is less than 0.6.**"
-      ]
+      "source": "## 8. See which celebrity you look most like! \n\nIn this step, you'll need to upload a picture of yourself.\nNote that your image MUST be at least 160x160 pixels. Head-shots and zoomed-in photos work better as we don't preprocess the image to just isolate the facial context! We only have 7,000 pictures so matching might be limited.\n\n1. Run the code cell\n2. Upload your picture\n3. Wait for the match!\n\n**A low score for matching is less than 0.6.**"
     },
     {
       "cell_type": "code",
@@ -337,187 +134,29 @@
       "id": "985fdb94-38fd-42c9-aaff-16620db0e954",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "def prewhiten(x: np.ndarray) -> np.ndarray:\n",
-        "    \"\"\"Prewhiten image data.\"\"\"\n",
-        "    mean = np.mean(x)\n",
-        "    std = np.std(x)\n",
-        "    std_adj = np.maximum(std, 1.0 / np.sqrt(x.size))\n",
-        "    y = np.multiply(np.subtract(x, mean), 1 / std_adj)\n",
-        "    return y\n",
-        "\n",
-        "\n",
-        "def crop(image: np.ndarray, random_crop: bool, image_size: int) -> np.ndarray:\n",
-        "    \"\"\"Crop an image to a given size.\"\"\"\n",
-        "    if image.shape[1] > image_size:\n",
-        "        sz1 = int(image.shape[1] // 2)\n",
-        "        sz2 = int(image_size // 2)\n",
-        "        if random_crop:\n",
-        "            diff = sz1 - sz2\n",
-        "            (h, v) = (np.random.randint(-diff, diff + 1), np.random.randint(-diff, diff + 1))\n",
-        "        else:\n",
-        "            (h, v) = (0, 0)\n",
-        "        image = image[(sz1 - sz2 + v):(sz1 + sz2 + v), (sz1 - sz2 + h):(sz1 + sz2 + h), :]\n",
-        "    return image\n",
-        "\n",
-        "\n",
-        "def flip(image: np.ndarray, random_flip: bool) -> np.ndarray:\n",
-        "    \"\"\"Flip the image data left-to-right.\"\"\"\n",
-        "    if random_flip and np.random.choice([True, False]):\n",
-        "        image = np.fliplr(image)\n",
-        "    return image\n",
-        "\n",
-        "\n",
-        "def load_data(\n",
-        "    image_paths: list[str],\n",
-        "    do_random_crop: bool,\n",
-        "    do_random_flip: bool,\n",
-        "    image_size: int,\n",
-        "    do_prewhiten: bool=True,\n",
-        ") -> np.ndarray:\n",
-        "    nrof_samples = len(image_paths)\n",
-        "    images = np.zeros((nrof_samples, image_size, image_size, 3))\n",
-        "    for i in range(nrof_samples):\n",
-        "        img = cv2.imread(image_paths[i])\n",
-        "        if do_prewhiten:\n",
-        "            img = prewhiten(img)\n",
-        "        img = crop(img, do_random_crop, image_size)\n",
-        "        img = flip(img, do_random_flip)\n",
-        "        images[i, :, :, :] = img\n",
-        "    return images\n",
-        "\n",
-        "\n",
-        "new_out= widgets.Output(layout={'border': '1px solid black'})\n",
-        "\n",
-        "s3 = boto3.resource('s3', region_name='us-east-1', config=Config(signature_version=UNSIGNED))\n",
-        "bucket = s3.Bucket('studiotutorials')\n",
-        "prefix = 'face_matching/'\n",
-        "names=[]\n",
-        "\n",
-        "local_folder = './face_matching_models'\n",
-        "if not os.path.exists(local_folder):\n",
-        "    os.makedirs(local_folder)   \n",
-        "\n",
-        "s3 = boto3.client('s3', region_name='us-east-1', config=Config(signature_version=UNSIGNED))\n",
-        "s3.download_file('studiotutorials', 'face_matching_models/20170512-110547.pb',\n",
-        "                 os.path.join(local_folder, '20170512-110547.pb'))\n",
-        "pb_file_path = './face_matching_models/20170512-110547.pb'\n",
-        "\n",
-        "# Load the .pb file into a graph\n",
-        "with tf.io.gfile.GFile(pb_file_path, 'rb') as f:\n",
-        "    graph_def = tf.compat.v1.GraphDef()\n",
-        "    graph_def.ParseFromString(f.read())\n",
-        "\n",
-        "\n",
-        "def handle_upload(change: widgets.Output) -> None:        \n",
-        "    with new_out:\n",
-        "        new_out.clear_output();\n",
-        "        new_file_name=''\n",
-        "        \n",
-        "        # Get the uploaded file\n",
-        "        uploaded_file = change.new\n",
-        "        if uploaded_file[0]['name'].lower().endswith(('.png', '.jpg', '.jpeg')):\n",
-        "            # Do something with the uploaded file\n",
-        "            file_name = uploaded_file[0]['name']\n",
-        "            random_number = random.randint(1, 100000000)\n",
-        "            new_file_name = f\"{file_name.split('.')[0]}_{random_number}.{file_name.split('.')[-1]}\"\n",
-        "            file_content = uploaded_file[0]['content']\n",
-        "            with open(new_file_name, 'wb') as f:\n",
-        "                f.write(file_content)\n",
-        "            with tf.compat.v1.Session() as sess:\n",
-        "                sess.graph.as_default()\n",
-        "                tf.import_graph_def(graph_def, name='')\n",
-        "                images_placeholder = sess.graph.get_tensor_by_name(\"input:0\")\n",
-        "                embeddings = sess.graph.get_tensor_by_name(\"embeddings:0\")\n",
-        "                phase_train_placeholder = tf.get_default_graph().get_tensor_by_name(\"phase_train:0\")\n",
-        "                phase_train = False\n",
-        "                img = load_data([new_file_name], False, False, 160)\n",
-        "                feed_dict = {\n",
-        "                    images_placeholder: img,         \n",
-        "                    phase_train_placeholder: phase_train,\n",
-        "                }\n",
-        "                embeddings_ = sess.run(embeddings, feed_dict=feed_dict)\n",
-        "                embeddings_list = [float(x) for x in embeddings_[0]]\n",
-        "                embeddings_json = json.dumps(embeddings_list)\n",
-        "                %sql insert into people values('{{new_file_name}}', json_array_pack_f32(\"{{embddings_json}}\"));\n",
-        "        else:\n",
-        "            print(\"Upload a .png, .jpg or .jpeg image\")\n",
-        "        \n",
-        "        num_matches = 5\n",
-        "        countdb = %sql SELECT COUNT(*) FROM people WHERE filename = '{{new_file_name}}';\n",
-        "\n",
-        "        if int(countdb[-1][0]) > 0: \n",
-        "            %sql SET @v = (SELECT vector FROM people WHERE filename = '{{new_file_name}}');\n",
-        "            result = %sql SELECT filename, DOT_PRODUCT(vector, @v) AS score FROM people ORDER BY score DESC LIMIT 5;\n",
-        "            images = []\n",
-        "            matches = []\n",
-        "            images.append(new_file_name)\n",
-        "            cnt = 0\n",
-        "            for res in result:\n",
-        "                print(res)\n",
-        "                if (cnt == 0):\n",
-        "                    temp_file = new_file_name\n",
-        "                else:\n",
-        "                    temp_file = \"match\" + str(cnt) + \".jpg\"\n",
-        "                    try:\n",
-        "                        bucket.download_file(prefix + res[0], temp_file)\n",
-        "                    except botocore.exceptions.ClientError as e:\n",
-        "                        if e.response['Error']['Code'] == \"404\":\n",
-        "                            bucket.download_file(prefix + \"error.jpg\", temp_file)\n",
-        "                        else:\n",
-        "                            raise\n",
-        "                images.append(temp_file)\n",
-        "                matches.append(res[1])\n",
-        "                cnt += 1\n",
-        "            fig, axes = plt.subplots(nrows=1, ncols=num_matches+1, figsize=(40, 40))\n",
-        "            %sql DELETE FROM people WHERE filename = '{{new_file_name}}';\n",
-        "            for i in range(num_matches+1):\n",
-        "                axes[i].imshow(plt.imread(images[i]))\n",
-        "                axes[i].set_xticks([])\n",
-        "                axes[i].set_yticks([])\n",
-        "                axes[i].set_xlabel('')\n",
-        "                axes[i].set_ylabel('')\n",
-        "                if i == 0:\n",
-        "                  axes[i].set_title(\"Original Image\", fontsize=14)\n",
-        "                else:\n",
-        "                  axes[i].set_title(\"Match \" + str(i) + \". Score: \" + str(matches[i-1]), fontsize=14)\n",
-        "            plt.show()\n",
-        "        else:\n",
-        "            print(\"No match for this image as it was not inserted into the People Database\")\n",
-        "\n",
-        "upload_button = widgets.FileUpload()\n",
-        "display(upload_button)\n",
-        "upload_button.observe(handle_upload, names='value')\n",
-        "display(new_out)"
-      ]
+      "source": "def prewhiten(x: np.ndarray) -> np.ndarray:\n    \"\"\"Prewhiten image data.\"\"\"\n    mean = np.mean(x)\n    std = np.std(x)\n    std_adj = np.maximum(std, 1.0 / np.sqrt(x.size))\n    y = np.multiply(np.subtract(x, mean), 1 / std_adj)\n    return y\n\n\ndef crop(image: np.ndarray, random_crop: bool, image_size: int) -> np.ndarray:\n    \"\"\"Crop an image to a given size.\"\"\"\n    if image.shape[1] > image_size:\n        sz1 = int(image.shape[1] // 2)\n        sz2 = int(image_size // 2)\n        if random_crop:\n            diff = sz1 - sz2\n            (h, v) = (np.random.randint(-diff, diff + 1), np.random.randint(-diff, diff + 1))\n        else:\n            (h, v) = (0, 0)\n        image = image[(sz1 - sz2 + v):(sz1 + sz2 + v), (sz1 - sz2 + h):(sz1 + sz2 + h), :]\n    return image\n\n\ndef flip(image: np.ndarray, random_flip: bool) -> np.ndarray:\n    \"\"\"Flip the image data left-to-right.\"\"\"\n    if random_flip and np.random.choice([True, False]):\n        image = np.fliplr(image)\n    return image\n\n\ndef load_data(\n    image_paths: list[str],\n    do_random_crop: bool,\n    do_random_flip: bool,\n    image_size: int,\n    do_prewhiten: bool=True,\n) -> np.ndarray:\n    nrof_samples = len(image_paths)\n    images = np.zeros((nrof_samples, image_size, image_size, 3))\n    for i in range(nrof_samples):\n        img = cv2.imread(image_paths[i])\n        if do_prewhiten:\n            img = prewhiten(img)\n        img = crop(img, do_random_crop, image_size)\n        img = flip(img, do_random_flip)\n        images[i, :, :, :] = img\n    return images\n\n\nnew_out= widgets.Output(layout={'border': '1px solid black'})\n\ns3 = boto3.resource('s3', region_name='us-east-1', config=Config(signature_version=UNSIGNED))\nbucket = s3.Bucket('studiotutorials')\nprefix = 'face_matching/'\nnames=[]\n\nlocal_folder = './face_matching_models'\nif not os.path.exists(local_folder):\n    os.makedirs(local_folder)   \n\ns3 = boto3.client('s3', region_name='us-east-1', config=Config(signature_version=UNSIGNED))\ns3.download_file('studiotutorials', 'face_matching_models/20170512-110547.pb',\n                 os.path.join(local_folder, '20170512-110547.pb'))\npb_file_path = './face_matching_models/20170512-110547.pb'\n\n# Load the .pb file into a graph\nwith tf.io.gfile.GFile(pb_file_path, 'rb') as f:\n    graph_def = tf.compat.v1.GraphDef()\n    graph_def.ParseFromString(f.read())\n\n\ndef handle_upload(change: widgets.Output) -> None:        \n    with new_out:\n        new_out.clear_output();\n        new_file_name=''\n        \n        # Get the uploaded file\n        uploaded_file = change.new\n        if uploaded_file[0]['name'].lower().endswith(('.png', '.jpg', '.jpeg')):\n            # Do something with the uploaded file\n            file_name = uploaded_file[0]['name']\n            random_number = random.randint(1, 100000000)\n            new_file_name = f\"{file_name.split('.')[0]}_{random_number}.{file_name.split('.')[-1]}\"\n            file_content = uploaded_file[0]['content']\n            with open(new_file_name, 'wb') as f:\n                f.write(file_content)\n            with tf.compat.v1.Session() as sess:\n                sess.graph.as_default()\n                tf.import_graph_def(graph_def, name='')\n                images_placeholder = sess.graph.get_tensor_by_name(\"input:0\")\n                embeddings = sess.graph.get_tensor_by_name(\"embeddings:0\")\n                phase_train_placeholder = tf.get_default_graph().get_tensor_by_name(\"phase_train:0\")\n                phase_train = False\n                img = load_data([new_file_name], False, False, 160)\n                feed_dict = {\n                    images_placeholder: img,         \n                    phase_train_placeholder: phase_train,\n                }\n                embeddings_ = sess.run(embeddings, feed_dict=feed_dict)\n                embeddings_list = [float(x) for x in embeddings_[0]]\n                embeddings_json = json.dumps(embeddings_list)\n                %sql insert into people values('{{new_file_name}}', json_array_pack_f32(\"{{embddings_json}}\"));\n        else:\n            print(\"Upload a .png, .jpg or .jpeg image\")\n        \n        num_matches = 5\n        countdb = %sql SELECT COUNT(*) FROM people WHERE filename = '{{new_file_name}}';\n\n        if int(countdb[-1][0]) > 0: \n            %sql SET @v = (SELECT vector FROM people WHERE filename = '{{new_file_name}}');\n            result = %sql SELECT filename, DOT_PRODUCT(vector, @v) AS score FROM people ORDER BY score DESC LIMIT 5;\n            images = []\n            matches = []\n            images.append(new_file_name)\n            cnt = 0\n            for res in result:\n                print(res)\n                if (cnt == 0):\n                    temp_file = new_file_name\n                else:\n                    temp_file = \"match\" + str(cnt) + \".jpg\"\n                    try:\n                        bucket.download_file(prefix + res[0], temp_file)\n                    except botocore.exceptions.ClientError as e:\n                        if e.response['Error']['Code'] == \"404\":\n                            bucket.download_file(prefix + \"error.jpg\", temp_file)\n                        else:\n                            raise\n                images.append(temp_file)\n                matches.append(res[1])\n                cnt += 1\n            fig, axes = plt.subplots(nrows=1, ncols=num_matches+1, figsize=(40, 40))\n            %sql DELETE FROM people WHERE filename = '{{new_file_name}}';\n            for i in range(num_matches+1):\n                axes[i].imshow(plt.imread(images[i]))\n                axes[i].set_xticks([])\n                axes[i].set_yticks([])\n                axes[i].set_xlabel('')\n                axes[i].set_ylabel('')\n                if i == 0:\n                  axes[i].set_title(\"Original Image\", fontsize=14)\n                else:\n                  axes[i].set_title(\"Match \" + str(i) + \". Score: \" + str(matches[i-1]), fontsize=14)\n            plt.show()\n        else:\n            print(\"No match for this image as it was not inserted into the People Database\")\n\nupload_button = widgets.FileUpload()\ndisplay(upload_button)\nupload_button.observe(handle_upload, names='value')\ndisplay(new_out)"
     },
     {
       "cell_type": "markdown",
       "id": "f3f3c685-0335-46e2-9a8d-e46ec296f074",
       "metadata": {},
-      "source": [
-        "## 9. Clean up"
-      ]
+      "source": "## 9. Clean up"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "51614d50-1e1f-4fe5-ab8d-09c804619edb",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE image_recognition;"
-      ]
+      "source": "DROP DATABASE image_recognition;"
     },
     {
       "cell_type": "markdown",
       "id": "83729541-f1c7-4d12-8162-e82a3ea991a1",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -536,7 +175,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/integrating-with-pandas/notebook.ipynb
+++ b/notebooks/integrating-with-pandas/notebook.ipynb
@@ -4,29 +4,13 @@
       "cell_type": "markdown",
       "id": "5c33f6a3-69f0-400d-813f-3889b1c08d2b",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(235, 249, 245, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/database.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Integrating pandas with SingleStoreDB</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(235, 249, 245, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/database.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Integrating pandas with SingleStoreDB</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "084012cb-df73-4887-a105-9d82e2755508",
       "metadata": {},
-      "source": [
-        "This notebook will show how to move data from a pandas `DataFrame` into SingleStoreDB as well\n",
-        "as downloading a SingleStoreDB query to a pandas `DataFrame`. It should be noted that this\n",
-        "is only intended for relatively small data sets and to do processing that can't otherwise\n",
-        "be done in SingleStoreDB itself. Moving data to the client for processing should only be done\n",
-        "when there is no other alternative in the database."
-      ]
+      "source": "This notebook will show how to move data from a pandas `DataFrame` into SingleStoreDB as well\nas downloading a SingleStoreDB query to a pandas `DataFrame`. It should be noted that this\nis only intended for relatively small data sets and to do processing that can't otherwise\nbe done in SingleStoreDB itself. Moving data to the client for processing should only be done\nwhen there is no other alternative in the database."
     },
     {
       "cell_type": "code",
@@ -34,22 +18,13 @@
       "id": "9d6f398e-e63c-4477-ab37-fbdcdd2d92f0",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import ibis\n",
-        "import pandas as pd\n",
-        "import singlestoredb as s2\n",
-        "import sqlalchemy as sa"
-      ]
+      "source": "import ibis\nimport pandas as pd\nimport singlestoredb as s2\nimport sqlalchemy as sa"
     },
     {
       "cell_type": "markdown",
       "id": "3b83e421-0ae5-46b3-a64d-25d77de7da0c",
       "metadata": {},
-      "source": [
-        "## Create a database\n",
-        "\n",
-        "We need to create a database to work with in the following examples."
-      ]
+      "source": "## Create a database\n\nWe need to create a database to work with in the following examples."
     },
     {
       "cell_type": "code",
@@ -57,54 +32,25 @@
       "id": "7b0ca2e7-52ec-4d97-b3e6-31ee4a2bd466",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE IF EXISTS pandas_integration;\n",
-        "\n",
-        "CREATE DATABASE IF NOT EXISTS pandas_integration;"
-      ]
+      "source": "%%sql\nDROP DATABASE IF EXISTS pandas_integration;\n\nCREATE DATABASE IF NOT EXISTS pandas_integration;"
     },
     {
       "cell_type": "markdown",
       "id": "641ab7fd-a344-42f0-9cd9-755056374581",
       "metadata": {},
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n",
-        "    <div>\n",
-        "        <p><b>Action Required</b></p>\n",
-        "        <p>Make sure to select the <tt>pandas_integration</tt> database from the drop-down menu at the top of this notebook.\n",
-        "        It updates the <tt>connection_url</tt> to connect to that database.</p>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div class=\"alert alert-block alert-warning\">\n    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n    <div>\n        <p><b>Action Required</b></p>\n        <p>Make sure to select the <tt>pandas_integration</tt> database from the drop-down menu at the top of this notebook.\n        It updates the <tt>connection_url</tt> to connect to that database.</p>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "f094c4b2-dade-4432-9173-db590e7cb1dd",
       "metadata": {},
-      "source": [
-        "## Database connections\n",
-        "\n",
-        "In the notebooks environment, the connection string for the currently selected database is kept\n",
-        "in the `connection_url` variable as well as the `SINGLESTOREDB_URL` environment variable.\n",
-        "The connection variables are accessed automatically within the SingleStoreDB Python packages\n",
-        "so that you do not need connection parameters when connecting.\n",
-        "\n",
-        "In the following sections, we will connect to SingleStoreDB using each of the packages and demonstrate\n",
-        "techniques for moving data between pandas and SingleStoreDB."
-      ]
+      "source": "## Database connections\n\nIn the notebooks environment, the connection string for the currently selected database is kept\nin the `connection_url` variable as well as the `SINGLESTOREDB_URL` environment variable.\nThe connection variables are accessed automatically within the SingleStoreDB Python packages\nso that you do not need connection parameters when connecting.\n\nIn the following sections, we will connect to SingleStoreDB using each of the packages and demonstrate\ntechniques for moving data between pandas and SingleStoreDB."
     },
     {
       "cell_type": "markdown",
       "id": "a6ffcb91-b70b-4175-bad7-7d087483e66b",
       "metadata": {},
-      "source": [
-        "## The Iris data set\n",
-        "\n",
-        "We'll be using the Iris data set for the following examples. This data set includes five columns: `sepal_length`,\n",
-        "`sepal_width`, `petal_length`, `petal_width` and `class`."
-      ]
+      "source": "## The Iris data set\n\nWe'll be using the Iris data set for the following examples. This data set includes five columns: `sepal_length`,\n`sepal_width`, `petal_length`, `petal_width` and `class`."
     },
     {
       "cell_type": "code",
@@ -112,20 +58,13 @@
       "id": "68129a0f-7bb7-4c1b-bdab-dbb5c8cb43a3",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "iris = pd.read_csv('https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/'\n",
-        "                   'master/notebooks/integrating-with-pandas/data/iris.csv')\n",
-        "iris"
-      ]
+      "source": "iris = pd.read_csv('https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/'\n                   'master/notebooks/integrating-with-pandas/data/iris.csv')\niris"
     },
     {
       "cell_type": "markdown",
       "id": "ff5ef64c-1046-4db0-bb96-dd976c42db39",
       "metadata": {},
-      "source": [
-        "As you can see below, the first four columns are floats and the last column is a string \n",
-        "(represented as an `object` in `DataFrame`s)."
-      ]
+      "source": "As you can see below, the first four columns are floats and the last column is a string \n(represented as an `object` in `DataFrame`s)."
     },
     {
       "cell_type": "code",
@@ -133,37 +72,19 @@
       "id": "22392542-a71a-484b-9a3a-7e767d3bad07",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "iris.info()"
-      ]
+      "source": "iris.info()"
     },
     {
       "cell_type": "markdown",
       "id": "8ea1fa0c-247e-4aaa-98a1-0980921fcaf7",
       "metadata": {},
-      "source": [
-        "## Moving data between SingleStoreDB and pandas `DataFrame`s\n",
-        "\n",
-        "Moving data from pandas `DataFrame`s to SingleStoreDB tables can be done in various ways from Python and even \n",
-        "from each of the packages described here. This reference is to show the best techniques when using each \n",
-        "package.\n",
-        "\n",
-        "It should be noted that moving data back-and-forth between pandas and SingleStoreDB should only be done when\n",
-        "absolutely needed since this can be a major bottleneck when working with and analyzing data. The hope is that\n",
-        "the features of SingleStoreDB are sufficient enough to alleviate the need to do much processing (if any) on \n",
-        "the client machine."
-      ]
+      "source": "## Moving data between SingleStoreDB and pandas `DataFrame`s\n\nMoving data from pandas `DataFrame`s to SingleStoreDB tables can be done in various ways from Python and even \nfrom each of the packages described here. This reference is to show the best techniques when using each \npackage.\n\nIt should be noted that moving data back-and-forth between pandas and SingleStoreDB should only be done when\nabsolutely needed since this can be a major bottleneck when working with and analyzing data. The hope is that\nthe features of SingleStoreDB are sufficient enough to alleviate the need to do much processing (if any) on \nthe client machine."
     },
     {
       "cell_type": "markdown",
       "id": "6d88c47a-7416-4566-b026-3e232afa7bc7",
       "metadata": {},
-      "source": [
-        "### SingleStoreDB Python\n",
-        "\n",
-        "The core library is the SingleStoreDB Python package. This is the package that all other SingleStoreDB\n",
-        "packages are built on. To connect, simply call the `connect` function."
-      ]
+      "source": "### SingleStoreDB Python\n\nThe core library is the SingleStoreDB Python package. This is the package that all other SingleStoreDB\npackages are built on. To connect, simply call the `connect` function."
     },
     {
       "cell_type": "code",
@@ -171,29 +92,19 @@
       "id": "a36c4a90-0aeb-402a-8454-764730ac4a08",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "s2_conn = s2.connect()"
-      ]
+      "source": "s2_conn = s2.connect()"
     },
     {
       "cell_type": "markdown",
       "id": "9e54271f-e185-4965-bfaf-2639c304d503",
       "metadata": {},
-      "source": [
-        "Since the core library is a fairly low-level interface to SingleStoreDB, most operations are done simply by sending\n",
-        "SQL code."
-      ]
+      "source": "Since the core library is a fairly low-level interface to SingleStoreDB, most operations are done simply by sending\nSQL code."
     },
     {
       "cell_type": "markdown",
       "id": "46f57610-87bd-45c8-84bd-e77c9b313527",
       "metadata": {},
-      "source": [
-        "#### Creating a table\n",
-        "\n",
-        "Because we are using a low-level driver, creating a table is just done using SQL code. We'll use the information\n",
-        "about the data set above to construct a `CREATE TABLE` statement."
-      ]
+      "source": "#### Creating a table\n\nBecause we are using a low-level driver, creating a table is just done using SQL code. We'll use the information\nabout the data set above to construct a `CREATE TABLE` statement."
     },
     {
       "cell_type": "code",
@@ -201,31 +112,13 @@
       "id": "4dc666be-0ce7-46bb-9afe-19f3435f02ff",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "s2_cur = s2_conn.cursor()\n",
-        "s2_cur.execute(r'''\n",
-        "    CREATE TABLE IF NOT EXISTS iris (\n",
-        "        sepal_length DOUBLE,\n",
-        "        sepal_width DOUBLE,\n",
-        "        petal_length DOUBLE,\n",
-        "        petal_width DOUBLE,\n",
-        "        class TEXT\n",
-        "    )\n",
-        "''')"
-      ]
+      "source": "s2_cur = s2_conn.cursor()\ns2_cur.execute(r'''\n    CREATE TABLE IF NOT EXISTS iris (\n        sepal_length DOUBLE,\n        sepal_width DOUBLE,\n        petal_length DOUBLE,\n        petal_width DOUBLE,\n        class TEXT\n    )\n''')"
     },
     {
       "cell_type": "markdown",
       "id": "29c23826-1862-48ec-a837-a3e25ea52362",
       "metadata": {},
-      "source": [
-        "#### Upload the data from a `DataFrame`\n",
-        "\n",
-        "Now that we have a table, we can populate it with data from the `DataFrame`. Again, we will use\n",
-        "SQL statements to do this. The Python client can execute single SQL statements using the \n",
-        "`execute` method as used above, but since we are uploading multiple rows of data it is better\n",
-        "to use the `executemany` method since it is optimized for this purpose. "
-      ]
+      "source": "#### Upload the data from a `DataFrame`\n\nNow that we have a table, we can populate it with data from the `DataFrame`. Again, we will use\nSQL statements to do this. The Python client can execute single SQL statements using the \n`execute` method as used above, but since we are uploading multiple rows of data it is better\nto use the `executemany` method since it is optimized for this purpose. "
     },
     {
       "cell_type": "code",
@@ -233,27 +126,13 @@
       "id": "c7347b35-f82d-4bf4-bc7d-75a1ecd478e2",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "# Construct the list of column names\n",
-        "cols = ', '.join(f'`{x}`' for x in iris.columns)\n",
-        "\n",
-        "# Construct a list of value placeholders for the INSERT statement\n",
-        "values = ', '.join(['%s'] * len(iris.columns))\n",
-        "\n",
-        "# Get data as a list of tuples (not including the index)\n",
-        "data = list(iris.itertuples(index=False))\n",
-        "\n",
-        "# Execute the INSERT statement\n",
-        "s2_cur.executemany(f'INSERT INTO iris({cols}) VALUES ({values})', data)"
-      ]
+      "source": "# Construct the list of column names\ncols = ', '.join(f'`{x}`' for x in iris.columns)\n\n# Construct a list of value placeholders for the INSERT statement\nvalues = ', '.join(['%s'] * len(iris.columns))\n\n# Get data as a list of tuples (not including the index)\ndata = list(iris.itertuples(index=False))\n\n# Execute the INSERT statement\ns2_cur.executemany(f'INSERT INTO iris({cols}) VALUES ({values})', data)"
     },
     {
       "cell_type": "markdown",
       "id": "f4846819-8043-4917-8b37-20ed4b4ab7ab",
       "metadata": {},
-      "source": [
-        "We can select a sample of the rows to see that the data is now in SingleStoreDB."
-      ]
+      "source": "We can select a sample of the rows to see that the data is now in SingleStoreDB."
     },
     {
       "cell_type": "code",
@@ -261,22 +140,13 @@
       "id": "801a8262-375a-40fc-8b2c-c15a8cee61a7",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "s2_cur.execute('SELECT * FROM iris LIMIT 10')\n",
-        "for row in s2_cur:\n",
-        "    print(row)"
-      ]
+      "source": "s2_cur.execute('SELECT * FROM iris LIMIT 10')\nfor row in s2_cur:\n    print(row)"
     },
     {
       "cell_type": "markdown",
       "id": "ff3de53a-76a8-44f5-a999-364692df4601",
       "metadata": {},
-      "source": [
-        "#### Downloading the data to a `DataFrame`\n",
-        "\n",
-        "We can download the data to a pandas `DataFrame` simply by selecting all columns of data, \n",
-        "fetching all of the rows, and passing them to the `DataFrame` constructor."
-      ]
+      "source": "#### Downloading the data to a `DataFrame`\n\nWe can download the data to a pandas `DataFrame` simply by selecting all columns of data, \nfetching all of the rows, and passing them to the `DataFrame` constructor."
     },
     {
       "cell_type": "code",
@@ -284,15 +154,7 @@
       "id": "de9bf4d0-72be-4f70-9efa-129b041acba6",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "s2_cur.execute('SELECT * FROM iris')\n",
-        "\n",
-        "# Use the `description` attribute to get the column names\n",
-        "names = [x[0] for x in s2_cur.description]\n",
-        "\n",
-        "s2_iris_df = pd.DataFrame(list(s2_cur), columns=names)\n",
-        "s2_iris_df"
-      ]
+      "source": "s2_cur.execute('SELECT * FROM iris')\n\n# Use the `description` attribute to get the column names\nnames = [x[0] for x in s2_cur.description]\n\ns2_iris_df = pd.DataFrame(list(s2_cur), columns=names)\ns2_iris_df"
     },
     {
       "cell_type": "code",
@@ -300,18 +162,13 @@
       "id": "ff2f9043-a940-43dc-974a-162e8bd2d576",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "s2_iris_df.info()"
-      ]
+      "source": "s2_iris_df.info()"
     },
     {
       "cell_type": "markdown",
       "id": "809ccd96-f00b-49ff-b19c-48d9b85c7e3f",
       "metadata": {},
-      "source": [
-        "Now that we have demonstrated uploading and downloading data from a pandas `DataFrame` using the\n",
-        "SingleStoreDB Python client, we can drop the table and move on to SQLAlchemy."
-      ]
+      "source": "Now that we have demonstrated uploading and downloading data from a pandas `DataFrame` using the\nSingleStoreDB Python client, we can drop the table and move on to SQLAlchemy."
     },
     {
       "cell_type": "code",
@@ -319,24 +176,13 @@
       "id": "8ef3cbb3-0f01-47c4-b27f-0dcf5729e7cd",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "s2_cur.execute('DROP TABLE IF EXISTS iris')"
-      ]
+      "source": "s2_cur.execute('DROP TABLE IF EXISTS iris')"
     },
     {
       "cell_type": "markdown",
       "id": "75788e0a-df76-4be7-8ced-d01fdc37d7b6",
       "metadata": {},
-      "source": [
-        "### SQLAlchemy\n",
-        "\n",
-        "In addition to the core Python library, you can use SQLAlchemy to connect to SingleStoreDB. Typically, when \n",
-        "using SQLAlchemy, you would use the SQLAlchemy `create_engine` function to create an engine, then call `connect`\n",
-        "on the engine to create connections from a pool. The SingleStoreDB Python package also has a `create_engine`\n",
-        "function that does the same thing, however, it extends the default ability by allow you to use the \n",
-        "`SINGLESTOREDB_URL` environment variable as the connection string so that no parameters are needed for\n",
-        "`create_engine` when used in the notebooks environment."
-      ]
+      "source": "### SQLAlchemy\n\nIn addition to the core Python library, you can use SQLAlchemy to connect to SingleStoreDB. Typically, when \nusing SQLAlchemy, you would use the SQLAlchemy `create_engine` function to create an engine, then call `connect`\non the engine to create connections from a pool. The SingleStoreDB Python package also has a `create_engine`\nfunction that does the same thing, however, it extends the default ability by allow you to use the \n`SINGLESTOREDB_URL` environment variable as the connection string so that no parameters are needed for\n`create_engine` when used in the notebooks environment."
     },
     {
       "cell_type": "code",
@@ -344,23 +190,13 @@
       "id": "ea6ac741-7c01-4b34-95c8-59d97db70cab",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "sa_eng = s2.create_engine()\n",
-        "sa_conn = sa_eng.connect()"
-      ]
+      "source": "sa_eng = s2.create_engine()\nsa_conn = sa_eng.connect()"
     },
     {
       "cell_type": "markdown",
       "id": "a0f0463a-9796-4f23-8081-6589fce6463d",
       "metadata": {},
-      "source": [
-        "#### Uploading the data from a `DataFrame`\n",
-        "\n",
-        "Uploading data from a `DataFrame` using SQLAlchemy is much easier than the lower-level Python library.\n",
-        "The pandas library itself has the ability to communicate with SingleStoreDB using a SQLAlchemy connection.\n",
-        "In this case, the `DataFrame` can create the table and populate it in one step using the `to_sql` method.\n",
-        "The `to_sql` method has various options to modify its behavior [documented on the pandas web site](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_sql.html)."
-      ]
+      "source": "#### Uploading the data from a `DataFrame`\n\nUploading data from a `DataFrame` using SQLAlchemy is much easier than the lower-level Python library.\nThe pandas library itself has the ability to communicate with SingleStoreDB using a SQLAlchemy connection.\nIn this case, the `DataFrame` can create the table and populate it in one step using the `to_sql` method.\nThe `to_sql` method has various options to modify its behavior [documented on the pandas web site](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_sql.html)."
     },
     {
       "cell_type": "code",
@@ -368,17 +204,13 @@
       "id": "de2c953c-09b9-4aa9-b491-751929322c19",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "iris.to_sql('iris', con=sa_conn, index=False, if_exists='replace')"
-      ]
+      "source": "iris.to_sql('iris', con=sa_conn, index=False, if_exists='replace')"
     },
     {
       "cell_type": "markdown",
       "id": "e4574813-c134-4c0a-8915-94c0c466863f",
       "metadata": {},
-      "source": [
-        "We can verify the data is in SingleStoreDB with a simple `SELECT` statement."
-      ]
+      "source": "We can verify the data is in SingleStoreDB with a simple `SELECT` statement."
     },
     {
       "cell_type": "code",
@@ -386,18 +218,13 @@
       "id": "6068dabe-5347-4449-926d-f52c0fb58b13",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "for row in sa_conn.execute('SELECT * FROM iris LIMIT 10'):\n",
-        "    print(row)"
-      ]
+      "source": "for row in sa_conn.execute('SELECT * FROM iris LIMIT 10'):\n    print(row)"
     },
     {
       "cell_type": "markdown",
       "id": "75b0a1ee-8c21-4b8a-856e-643485661bdf",
       "metadata": {},
-      "source": [
-        "It is also possible to use SQLAlchemy expressions to query the table rather than raw SQL strings."
-      ]
+      "source": "It is also possible to use SQLAlchemy expressions to query the table rather than raw SQL strings."
     },
     {
       "cell_type": "code",
@@ -405,32 +232,13 @@
       "id": "60e13489-3d70-48c1-b17b-baebb0d0543c",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "# Create a metadata object for the database\n",
-        "db = sa.MetaData(bind=sa_eng)\n",
-        "sa.MetaData.reflect(db)\n",
-        "\n",
-        "# Get the iris table from reflected data\n",
-        "sa_iris = db.tables['iris']\n",
-        "\n",
-        "# Query the iris table\n",
-        "query = sa.select(sa_iris).limit(10)\n",
-        "\n",
-        "# Print results\n",
-        "for row in sa_conn.execute(query):\n",
-        "    print(row)"
-      ]
+      "source": "# Create a metadata object for the database\ndb = sa.MetaData(bind=sa_eng)\nsa.MetaData.reflect(db)\n\n# Get the iris table from reflected data\nsa_iris = db.tables['iris']\n\n# Query the iris table\nquery = sa.select(sa_iris).limit(10)\n\n# Print results\nfor row in sa_conn.execute(query):\n    print(row)"
     },
     {
       "cell_type": "markdown",
       "id": "0db80753-98a7-4748-83fe-1190cd04415f",
       "metadata": {},
-      "source": [
-        "#### Downloading the data to a `DataFrame`\n",
-        "\n",
-        "Downloading data to a pandas `DataFrame` is very simple. The result of the `execute` method can \n",
-        "be passed directly to the pandas `DataFrame` constructor."
-      ]
+      "source": "#### Downloading the data to a `DataFrame`\n\nDownloading data to a pandas `DataFrame` is very simple. The result of the `execute` method can \nbe passed directly to the pandas `DataFrame` constructor."
     },
     {
       "cell_type": "code",
@@ -438,13 +246,7 @@
       "id": "6053dcf8-8774-4e73-a5d7-2a86bb597569",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "# Reset query to not include the limit\n",
-        "query = sa.select(sa_iris)\n",
-        "\n",
-        "sa_iris_df = pd.DataFrame(sa_conn.execute(query))\n",
-        "sa_iris_df"
-      ]
+      "source": "# Reset query to not include the limit\nquery = sa.select(sa_iris)\n\nsa_iris_df = pd.DataFrame(sa_conn.execute(query))\nsa_iris_df"
     },
     {
       "cell_type": "code",
@@ -452,17 +254,13 @@
       "id": "5c2a5a7b-a00d-48b5-8e8b-b19e08d5d792",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "sa_iris_df.info()"
-      ]
+      "source": "sa_iris_df.info()"
     },
     {
       "cell_type": "markdown",
       "id": "a8977c4c-a0a8-4299-b7bb-d1c03e386169",
       "metadata": {},
-      "source": [
-        "It is also possible to use `pd.read_sql` to bookend the use of `df.to_sql`."
-      ]
+      "source": "It is also possible to use `pd.read_sql` to bookend the use of `df.to_sql`."
     },
     {
       "cell_type": "code",
@@ -470,19 +268,13 @@
       "id": "a200df59-efb2-42e6-bca5-1b115666fb2d",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "sa_iris_df = pd.read_sql(query, con=sa_conn)\n",
-        "sa_iris_df"
-      ]
+      "source": "sa_iris_df = pd.read_sql(query, con=sa_conn)\nsa_iris_df"
     },
     {
       "cell_type": "markdown",
       "id": "c1dd2d93-f330-4e3a-b39a-32accc3d1a60",
       "metadata": {},
-      "source": [
-        "Now that we have demonstrated using SQLAlchemy to upload and download pandas `DataFrames` we can drop \n",
-        "the table and move on to Ibis."
-      ]
+      "source": "Now that we have demonstrated using SQLAlchemy to upload and download pandas `DataFrames` we can drop \nthe table and move on to Ibis."
     },
     {
       "cell_type": "code",
@@ -490,21 +282,13 @@
       "id": "65eb886b-cdb6-4dae-bfaf-57a03d23cd51",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "sa_iris.drop()"
-      ]
+      "source": "sa_iris.drop()"
     },
     {
       "cell_type": "markdown",
       "id": "5693eca8-fa3c-46ad-94fb-73d02ca50478",
       "metadata": {},
-      "source": [
-        "### Ibis (SingleStoreDB DataFrame)\n",
-        "\n",
-        "The Ibis package allows you to treat tables in SingleStoreDB as `DataFrames`. The `DataFrame` expressions\n",
-        "are used to build lazy expressions which generate SQL statements that get submitted to SingleStoreDB\n",
-        "only when you want to see the results of a query. Ibis using SQLAlchemy connections behind-the-scenes."
-      ]
+      "source": "### Ibis (SingleStoreDB DataFrame)\n\nThe Ibis package allows you to treat tables in SingleStoreDB as `DataFrames`. The `DataFrame` expressions\nare used to build lazy expressions which generate SQL statements that get submitted to SingleStoreDB\nonly when you want to see the results of a query. Ibis using SQLAlchemy connections behind-the-scenes."
     },
     {
       "cell_type": "code",
@@ -512,29 +296,13 @@
       "id": "686b8296-d50e-4a0b-b464-8b7807417f79",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "ibis_conn = ibis.singlestoredb.connect()"
-      ]
+      "source": "ibis_conn = ibis.singlestoredb.connect()"
     },
     {
       "cell_type": "markdown",
       "id": "254fd629-e321-434f-a257-ccc3874ac93b",
       "metadata": {},
-      "source": [
-        "#### Uploading the data from a `DataFrame`\n",
-        "\n",
-        "Ibis is intended for tight integration with pandas, so it is no surprise that uploading a \n",
-        "pandas `DataFrame` with Ibis is straight-forward. \n",
-        "\n",
-        "If you are not familiar with Ibis, you may notice the `execute` call at the end of this cell.\n",
-        "Ibis creates expressions in memory on the client machine until a view of the data is \n",
-        "explicitly asked for. Once you explicitly ask for a query to be executed, it then generates\n",
-        "and submits the SQL code for the expression behind-the-scenes.\n",
-        "\n",
-        "In this case, the `ibis_iris` object is a `DataFrame`-like object that is lazily constructing\n",
-        "the requested expression until `execute` is called on it. In the case of this example, uploading\n",
-        "and downloading "
-      ]
+      "source": "#### Uploading the data from a `DataFrame`\n\nIbis is intended for tight integration with pandas, so it is no surprise that uploading a \npandas `DataFrame` with Ibis is straight-forward. \n\nIf you are not familiar with Ibis, you may notice the `execute` call at the end of this cell.\nIbis creates expressions in memory on the client machine until a view of the data is \nexplicitly asked for. Once you explicitly ask for a query to be executed, it then generates\nand submits the SQL code for the expression behind-the-scenes.\n\nIn this case, the `ibis_iris` object is a `DataFrame`-like object that is lazily constructing\nthe requested expression until `execute` is called on it. In the case of this example, uploading\nand downloading "
     },
     {
       "cell_type": "code",
@@ -542,19 +310,13 @@
       "id": "0ca99ab2-bd93-41da-98f7-82c0d9934f43",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "ibis_iris = ibis_conn.create_table('iris', iris, force=True)\n",
-        "ibis_iris.limit(10).execute()"
-      ]
+      "source": "ibis_iris = ibis_conn.create_table('iris', iris, force=True)\nibis_iris.limit(10).execute()"
     },
     {
       "cell_type": "markdown",
       "id": "49bb8050-a6f4-4a6d-b083-78b324ebc755",
       "metadata": {},
-      "source": [
-        "It is also possible to insert the data from a `DataFrame` into an existing table using the `insert` method \n",
-        "of the connection."
-      ]
+      "source": "It is also possible to insert the data from a `DataFrame` into an existing table using the `insert` method \nof the connection."
     },
     {
       "cell_type": "code",
@@ -562,17 +324,13 @@
       "id": "d2841e5b-a8c9-41e3-a404-25d532e831d2",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "ibis_conn.insert('iris', iris)"
-      ]
+      "source": "ibis_conn.insert('iris', iris)"
     },
     {
       "cell_type": "markdown",
       "id": "60cc0488-04ae-4c8b-9641-f6ef07133ac8",
       "metadata": {},
-      "source": [
-        "You'll see that we now have 300 rows since we've inserted the data twice."
-      ]
+      "source": "You'll see that we now have 300 rows since we've inserted the data twice."
     },
     {
       "cell_type": "code",
@@ -580,18 +338,13 @@
       "id": "bc49e1ac-25b3-49e6-a257-c2bf2ace5be7",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "ibis_iris.count().execute()"
-      ]
+      "source": "ibis_iris.count().execute()"
     },
     {
       "cell_type": "markdown",
       "id": "125cc52e-37fe-4c9f-a573-c81f6363ff36",
       "metadata": {},
-      "source": [
-        "One way to see the SQL that gets submitted during `execute` is to compile the expression\n",
-        "and print it. Ibis also has a options to display SQL queries as they are submitted."
-      ]
+      "source": "One way to see the SQL that gets submitted during `execute` is to compile the expression\nand print it. Ibis also has a options to display SQL queries as they are submitted."
     },
     {
       "cell_type": "code",
@@ -599,17 +352,13 @@
       "id": "a1e4ccba-bec5-451c-9fd1-4b0ba87e5a74",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "print(ibis_iris.compile())"
-      ]
+      "source": "print(ibis_iris.compile())"
     },
     {
       "cell_type": "markdown",
       "id": "11e9fa6e-bb62-488c-a530-835ebd41d323",
       "metadata": {},
-      "source": [
-        "The information about the table can be retrieved much like in a local pandas `DataFrame`."
-      ]
+      "source": "The information about the table can be retrieved much like in a local pandas `DataFrame`."
     },
     {
       "cell_type": "code",
@@ -617,20 +366,13 @@
       "id": "2bfbb75b-ef83-4400-9909-348a12ac83cd",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "ibis_iris.info().execute()"
-      ]
+      "source": "ibis_iris.info().execute()"
     },
     {
       "cell_type": "markdown",
       "id": "1bb2e364-b2c2-4c07-81ea-3e20dec1c723",
       "metadata": {},
-      "source": [
-        "#### Downloading the data from a `DataFrame`\n",
-        "\n",
-        "The output from evaluating Ibis expressions returns a `DataFrame`, so we have already demonstrated\n",
-        "downloading data, but here is the code again."
-      ]
+      "source": "#### Downloading the data from a `DataFrame`\n\nThe output from evaluating Ibis expressions returns a `DataFrame`, so we have already demonstrated\ndownloading data, but here is the code again."
     },
     {
       "cell_type": "code",
@@ -638,18 +380,13 @@
       "id": "b9e14b01-9350-4560-81f9-cf68f4e105f5",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "ibis_iris_df = ibis_iris.execute()\n",
-        "ibis_iris_df"
-      ]
+      "source": "ibis_iris_df = ibis_iris.execute()\nibis_iris_df"
     },
     {
       "cell_type": "markdown",
       "id": "e399be8a-6c5b-46cd-9c6b-7b4d02a36e57",
       "metadata": {},
-      "source": [
-        "Ibis `Table`s also have a `to_pandas` method."
-      ]
+      "source": "Ibis `Table`s also have a `to_pandas` method."
     },
     {
       "cell_type": "code",
@@ -657,18 +394,13 @@
       "id": "c6623479-e200-4575-ae12-e415feb11237",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "ibis_iris.to_pandas()"
-      ]
+      "source": "ibis_iris.to_pandas()"
     },
     {
       "cell_type": "markdown",
       "id": "15feee4b-746b-4333-aabf-c8c061db9bb0",
       "metadata": {},
-      "source": [
-        "If you do not have an Ibis object reference to a table already, you can get one using the `table` method\n",
-        "or `tables` attribute of the Ibis connection."
-      ]
+      "source": "If you do not have an Ibis object reference to a table already, you can get one using the `table` method\nor `tables` attribute of the Ibis connection."
     },
     {
       "cell_type": "code",
@@ -676,13 +408,7 @@
       "id": "b1479ee9-10c6-47ac-b54e-3b3032c04949",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "# Use this version if the table name is not a valid Python variable name\n",
-        "ibis_iris = ibis_conn.table('iris')\n",
-        "\n",
-        "# This form can be used if the table name is a valid Python variable name\n",
-        "ibis_iris = ibis_conn.tables.iris"
-      ]
+      "source": "# Use this version if the table name is not a valid Python variable name\nibis_iris = ibis_conn.table('iris')\n\n# This form can be used if the table name is a valid Python variable name\nibis_iris = ibis_conn.tables.iris"
     },
     {
       "cell_type": "code",
@@ -690,18 +416,13 @@
       "id": "eec644ad-61e1-4ab7-9cb0-edf0ed2a1f81",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "ibis_iris.limit(10).execute()"
-      ]
+      "source": "ibis_iris.limit(10).execute()"
     },
     {
       "cell_type": "markdown",
       "id": "ef002757-d84c-4da2-a61c-48c424569261",
       "metadata": {},
-      "source": [
-        "We have demonstrated both uploading and downloading pandas `DataFrames` using Ibis, so \n",
-        "we can drop the table now."
-      ]
+      "source": "We have demonstrated both uploading and downloading pandas `DataFrames` using Ibis, so \nwe can drop the table now."
     },
     {
       "cell_type": "code",
@@ -709,33 +430,19 @@
       "id": "e96373d5-651c-4047-bda7-3e49bf6edb7a",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "ibis_conn.drop_table('iris')"
-      ]
+      "source": "ibis_conn.drop_table('iris')"
     },
     {
       "cell_type": "markdown",
       "id": "d885cce5-1ae9-43e1-ae13-6b98c43ca23b",
       "metadata": {},
-      "source": [
-        "### `%%sql` and `%sql` magic commands\n",
-        "\n",
-        "The IPython interpreter can be extended with \"magic\" commands. The SingleStore Cloud notebook environment\n",
-        "uses the [JupySQL](https://jupysql.ploomber.io/en/latest/quick-start.html) plugin for the `%sql`, `%%sql`,\n",
-        "and `%sqlplot` commands. These work in conjunction with SQLAlchemy to allow you to type SQL code in\n",
-        "the notebook cells. They also have ways of integrating with pandas. The notebook environment automatically\n",
-        "sets up the connection string for use in these commands."
-      ]
+      "source": "### `%%sql` and `%sql` magic commands\n\nThe IPython interpreter can be extended with \"magic\" commands. The SingleStore Cloud notebook environment\nuses the [JupySQL](https://jupysql.ploomber.io/en/latest/quick-start.html) plugin for the `%sql`, `%%sql`,\nand `%sqlplot` commands. These work in conjunction with SQLAlchemy to allow you to type SQL code in\nthe notebook cells. They also have ways of integrating with pandas. The notebook environment automatically\nsets up the connection string for use in these commands."
     },
     {
       "cell_type": "markdown",
       "id": "a474e845-0039-4625-a250-2ec5cf0adaaa",
       "metadata": {},
-      "source": [
-        "#### Creating a table\n",
-        "\n",
-        "Creating a table with the `%%sql` command is done simply by submitting the `CREATE TABLE` statement."
-      ]
+      "source": "#### Creating a table\n\nCreating a table with the `%%sql` command is done simply by submitting the `CREATE TABLE` statement."
     },
     {
       "cell_type": "code",
@@ -743,9 +450,7 @@
       "id": "68222c9a-72ea-4917-9733-f621fd386bfb",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%sql DROP TABLE iris;"
-      ]
+      "source": "%sql DROP TABLE iris;"
     },
     {
       "cell_type": "code",
@@ -753,29 +458,13 @@
       "id": "db10dca0-b2c5-43c9-8dcc-1f520fac7efb",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "CREATE TABLE IF NOT EXISTS iris (\n",
-        "    sepal_length DOUBLE,\n",
-        "    sepal_width DOUBLE,\n",
-        "    petal_length DOUBLE,\n",
-        "    petal_width DOUBLE,\n",
-        "    class TEXT\n",
-        ");"
-      ]
+      "source": "%%sql\nCREATE TABLE IF NOT EXISTS iris (\n    sepal_length DOUBLE,\n    sepal_width DOUBLE,\n    petal_length DOUBLE,\n    petal_width DOUBLE,\n    class TEXT\n);"
     },
     {
       "cell_type": "markdown",
       "id": "f0f53739-6d19-4be8-ae08-c5dca35acfef",
       "metadata": {},
-      "source": [
-        "#### Uploading the data from a `DataFrame`\n",
-        "\n",
-        "The `%sql` command has options that allow you to upload data from a `DataFrame`. The `--persist` option\n",
-        "will create a table in the database and upload the data. The `--append` option will append data to an \n",
-        "existing table. In this case, the name used for the `DataFrame` variable is used for the table name\n",
-        "in SingleStoreDB."
-      ]
+      "source": "#### Uploading the data from a `DataFrame`\n\nThe `%sql` command has options that allow you to upload data from a `DataFrame`. The `--persist` option\nwill create a table in the database and upload the data. The `--append` option will append data to an \nexisting table. In this case, the name used for the `DataFrame` variable is used for the table name\nin SingleStoreDB."
     },
     {
       "cell_type": "code",
@@ -783,9 +472,7 @@
       "id": "8839c965-880d-4909-88a0-b7fa8cb4723d",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%sql --append --no-index iris"
-      ]
+      "source": "%sql --append --no-index iris"
     },
     {
       "cell_type": "code",
@@ -793,21 +480,13 @@
       "id": "f11d4a80-9555-4067-9ada-2e4cf3ead35f",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "SELECT * FROM iris LIMIT 10;"
-      ]
+      "source": "%%sql\nSELECT * FROM iris LIMIT 10;"
     },
     {
       "cell_type": "markdown",
       "id": "da339a4c-84a6-4f7d-a802-4fdd9f40d2b9",
       "metadata": {},
-      "source": [
-        "#### Downloading the data from a `DataFrame`\n",
-        "\n",
-        "There are a few ways of getting data from SingleStoreDB into a `DataFrame` using the SQL magic commands.\n",
-        "The first is to use the `%sql` command and convert the result manually."
-      ]
+      "source": "#### Downloading the data from a `DataFrame`\n\nThere are a few ways of getting data from SingleStoreDB into a `DataFrame` using the SQL magic commands.\nThe first is to use the `%sql` command and convert the result manually."
     },
     {
       "cell_type": "code",
@@ -815,19 +494,13 @@
       "id": "4198f8b6-175d-4a16-963e-af7508e06487",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "out = %sql SELECT * FROM iris\n",
-        "sql_iris_df = out.DataFrame()\n",
-        "sql_iris_df"
-      ]
+      "source": "out = %sql SELECT * FROM iris\nsql_iris_df = out.DataFrame()\nsql_iris_df"
     },
     {
       "cell_type": "markdown",
       "id": "c5978394-d1fe-4c24-a3bd-9b8ce9583dcc",
       "metadata": {},
-      "source": [
-        "You can also pass the result of the query to the `DataFrame` constructor."
-      ]
+      "source": "You can also pass the result of the query to the `DataFrame` constructor."
     },
     {
       "cell_type": "code",
@@ -835,19 +508,13 @@
       "id": "4f008d44-efde-415c-b847-a7d351ac8157",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "sql_iris_df = pd.DataFrame(out)\n",
-        "sql_iris_df"
-      ]
+      "source": "sql_iris_df = pd.DataFrame(out)\nsql_iris_df"
     },
     {
       "cell_type": "markdown",
       "id": "01076d35-e406-453a-88c5-86f70b98e55e",
       "metadata": {},
-      "source": [
-        "Finally, the output of the `%%sql` command can be stored to a variable which can then be\n",
-        "converted to a `DataFrame` in the same manner as above."
-      ]
+      "source": "Finally, the output of the `%%sql` command can be stored to a variable which can then be\nconverted to a `DataFrame` in the same manner as above."
     },
     {
       "cell_type": "code",
@@ -855,10 +522,7 @@
       "id": "2bb36229-b336-462f-977f-36679d40f50f",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%%sql result << \n",
-        "SELECT * FROM iris;"
-      ]
+      "source": "%%sql result << \nSELECT * FROM iris;"
     },
     {
       "cell_type": "code",
@@ -866,22 +530,13 @@
       "id": "2094aa36-86bf-469b-9322-a9f94877f954",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "sql_iris_df = pd.DataFrame(result)\n",
-        "sql_iris_df"
-      ]
+      "source": "sql_iris_df = pd.DataFrame(result)\nsql_iris_df"
     },
     {
       "cell_type": "markdown",
       "id": "285fcfbb-5487-4195-9240-8af8462115fe",
       "metadata": {},
-      "source": [
-        "##### Automatically return pandas `DataFrame`s\n",
-        "\n",
-        "The other option for getting `DataFrame`s as the result of the SQL magic commands is to enable\n",
-        "the `SqlMagic.autopandas` option. This will cause all results from SQL magic commands to be\n",
-        "converted to `DataFrame`s without any intervention."
-      ]
+      "source": "##### Automatically return pandas `DataFrame`s\n\nThe other option for getting `DataFrame`s as the result of the SQL magic commands is to enable\nthe `SqlMagic.autopandas` option. This will cause all results from SQL magic commands to be\nconverted to `DataFrame`s without any intervention."
     },
     {
       "cell_type": "code",
@@ -889,9 +544,7 @@
       "id": "f19aee9c-fe28-4c0b-a902-c094ea76cfd1",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%config SqlMagic.autopandas = True"
-      ]
+      "source": "%config SqlMagic.autopandas = True"
     },
     {
       "cell_type": "code",
@@ -899,10 +552,7 @@
       "id": "6caba2b5-86b4-4abf-9063-e59bbac2aab3",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "out = %sql SELECT * FROM iris\n",
-        "out"
-      ]
+      "source": "out = %sql SELECT * FROM iris\nout"
     },
     {
       "cell_type": "code",
@@ -910,18 +560,13 @@
       "id": "129603ca-b982-4b77-9967-8c0fe0520f45",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "type(out)"
-      ]
+      "source": "type(out)"
     },
     {
       "cell_type": "markdown",
       "id": "929f83b9-bb1c-4d6f-9a5e-fdfc8db0db7e",
       "metadata": {},
-      "source": [
-        "Now that we have demonstrated uploading and downloading of `DataFrame`s using the SQL magic commands,\n",
-        "we can reset the configuration options and drop the table."
-      ]
+      "source": "Now that we have demonstrated uploading and downloading of `DataFrame`s using the SQL magic commands,\nwe can reset the configuration options and drop the table."
     },
     {
       "cell_type": "code",
@@ -929,22 +574,13 @@
       "id": "32a14f6f-7afa-442c-8e58-c317bccdbcb9",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%config SqlMagic.autopandas = False\n",
-        "%sql DROP TABLE IF EXISTS iris"
-      ]
+      "source": "%config SqlMagic.autopandas = False\n%sql DROP TABLE IF EXISTS iris"
     },
     {
       "cell_type": "markdown",
       "id": "6a832062-3934-4541-81b5-5c3cf0c117ac",
       "metadata": {},
-      "source": [
-        "## Conclusion\n",
-        "\n",
-        "We have shown how to upload and download data from a pandas `DataFrame` to and from SingleStoreDB\n",
-        "using the SingleStoreDB Python client, SQLAlchemy, and Ibis. These techniques should enable you to\n",
-        "integrate your pandas workflows with SingleStoreDB."
-      ]
+      "source": "## Conclusion\n\nWe have shown how to upload and download data from a pandas `DataFrame` to and from SingleStoreDB\nusing the SingleStoreDB Python client, SQLAlchemy, and Ibis. These techniques should enable you to\nintegrate your pandas workflows with SingleStoreDB."
     },
     {
       "cell_type": "code",
@@ -952,19 +588,13 @@
       "id": "6d6f10e5-7605-485b-82f3-7a26a17ae912",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE IF EXISTS pandas_integration;"
-      ]
+      "source": "%%sql\nDROP DATABASE IF EXISTS pandas_integration;"
     },
     {
       "cell_type": "markdown",
       "id": "dca02e68-11a8-46b9-b2eb-35f466d0c96e",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -989,7 +619,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/launch-open-source-apps-with-langchain/notebook.ipynb
+++ b/notebooks/launch-open-source-apps-with-langchain/notebook.ipynb
@@ -4,17 +4,7 @@
       "cell_type": "markdown",
       "id": "7d9894c5-8938-4790-8acf-44882f2d3391",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(209, 153, 255, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/vector-circle.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Launch Open-Source Apps with LangChain</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(209, 153, 255, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/vector-circle.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Launch Open-Source Apps with LangChain</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "code",
@@ -22,14 +12,7 @@
       "id": "be57e1dd-8030-4551-81bb-d25b1017188b",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip install langchain --quiet\n",
-        "!pip install openai --quiet\n",
-        "!pip install pdf2image --quiet\n",
-        "!pip install tabulate --quiet\n",
-        "!pip install tiktoken --quiet\n",
-        "!pip install unstructured --quiet"
-      ]
+      "source": "!pip install langchain --quiet\n!pip install openai --quiet\n!pip install pdf2image --quiet\n!pip install tabulate --quiet\n!pip install tiktoken --quiet\n!pip install unstructured --quiet"
     },
     {
       "cell_type": "code",
@@ -37,13 +20,7 @@
       "id": "b21ec610-517c-4fcc-bd19-217b2675c8a9",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "from langchain.document_loaders import OnlinePDFLoader\n",
-        "\n",
-        "loader = OnlinePDFLoader(\"http://leavcom.com/pdf/DBpdf.pdf\")\n",
-        "\n",
-        "data = loader.load()"
-      ]
+      "source": "from langchain.document_loaders import OnlinePDFLoader\n\nloader = OnlinePDFLoader(\"http://leavcom.com/pdf/DBpdf.pdf\")\n\ndata = loader.load()"
     },
     {
       "cell_type": "code",
@@ -51,12 +28,7 @@
       "id": "a40099c8-f859-4707-a3c9-635bbc693806",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
-        "\n",
-        "print (f\"You have {len(data)} document(s) in your data\")\n",
-        "print (f\"There are {len(data[0].page_content)} characters in your document\")"
-      ]
+      "source": "from langchain.text_splitter import RecursiveCharacterTextSplitter\n\nprint (f\"You have {len(data)} document(s) in your data\")\nprint (f\"There are {len(data[0].page_content)} characters in your document\")"
     },
     {
       "cell_type": "code",
@@ -64,12 +36,7 @@
       "id": "dd303fc1-d02b-460d-a81e-3a313cab1a59",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "text_splitter = RecursiveCharacterTextSplitter(chunk_size = 2000, chunk_overlap = 0)\n",
-        "texts = text_splitter.split_documents(data)\n",
-        "\n",
-        "print (f\"You have {len(texts)} pages\")"
-      ]
+      "source": "text_splitter = RecursiveCharacterTextSplitter(chunk_size = 2000, chunk_overlap = 0)\ntexts = text_splitter.split_documents(data)\n\nprint (f\"You have {len(texts)} pages\")"
     },
     {
       "cell_type": "code",
@@ -77,12 +44,7 @@
       "id": "5c05e57c-3300-4c1a-867c-383c621f2b94",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "\n",
-        "DROP DATABASE IF EXISTS pdf_db;\n",
-        "CREATE DATABASE IF NOT EXISTS pdf_db;"
-      ]
+      "source": "%%sql\n\nDROP DATABASE IF EXISTS pdf_db;\nCREATE DATABASE IF NOT EXISTS pdf_db;"
     },
     {
       "cell_type": "code",
@@ -90,17 +52,7 @@
       "id": "0d2c027b-883b-4e2b-9594-b5c4cc41af24",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "\n",
-        "USE pdf_db;\n",
-        "DROP TABLE IF EXISTS pdf_docs1;\n",
-        "CREATE TABLE IF NOT EXISTS pdf_docs1 (\n",
-        "    id INT PRIMARY KEY,\n",
-        "    content TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,\n",
-        "    vector BLOB\n",
-        ");"
-      ]
+      "source": "%%sql\n\nUSE pdf_db;\nDROP TABLE IF EXISTS pdf_docs1;\nCREATE TABLE IF NOT EXISTS pdf_docs1 (\n    id INT PRIMARY KEY,\n    content TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,\n    vector BLOB\n);"
     },
     {
       "cell_type": "code",
@@ -108,11 +60,7 @@
       "id": "ee2b2b89-859b-4c8b-b653-cc8df62be869",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "from singlestoredb import create_engine\n",
-        "\n",
-        "db_connection = create_engine().connect()"
-      ]
+      "source": "from singlestoredb import create_engine\n\ndb_connection = create_engine().connect()"
     },
     {
       "cell_type": "code",
@@ -120,12 +68,7 @@
       "id": "df0283f6-66fa-4b2e-bf5c-024864896c28",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import os\n",
-        "import getpass\n",
-        "\n",
-        "os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OpenAI API Key:\")"
-      ]
+      "source": "import os\nimport getpass\n\nos.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OpenAI API Key:\")"
     },
     {
       "cell_type": "code",
@@ -133,11 +76,7 @@
       "id": "c3709108-1fb7-469a-9f03-970b2f8cd9c3",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "from langchain.embeddings import OpenAIEmbeddings\n",
-        "\n",
-        "embedder = OpenAIEmbeddings()"
-      ]
+      "source": "from langchain.embeddings import OpenAIEmbeddings\n\nembedder = OpenAIEmbeddings()"
     },
     {
       "cell_type": "code",
@@ -145,27 +84,7 @@
       "id": "5b5d8f1c-e9a1-4010-bd77-fc209b52bdb6",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "for i, document in enumerate(texts):\n",
-        "    text_content = document.page_content\n",
-        "\n",
-        "    embedding = embedder.embed_documents([text_content])[0]\n",
-        "\n",
-        "    stmt = \"\"\"\n",
-        "        INSERT INTO pdf_docs1 (\n",
-        "            id,\n",
-        "            content,\n",
-        "            vector\n",
-        "        )\n",
-        "        VALUES (\n",
-        "            %s,\n",
-        "            %s,\n",
-        "            JSON_ARRAY_PACK_F32(%s)\n",
-        "        )\n",
-        "    \"\"\"\n",
-        "\n",
-        "    db_connection.execute(stmt, (i+1, text_content, str(embedding)))"
-      ]
+      "source": "for i, document in enumerate(texts):\n    text_content = document.page_content\n\n    embedding = embedder.embed_documents([text_content])[0]\n\n    stmt = \"\"\"\n        INSERT INTO pdf_docs1 (\n            id,\n            content,\n            vector\n        )\n        VALUES (\n            %s,\n            %s,\n            JSON_ARRAY_PACK_F32(%s)\n        )\n    \"\"\"\n\n    db_connection.execute(stmt, (i+1, text_content, str(embedding)))"
     },
     {
       "cell_type": "code",
@@ -173,14 +92,7 @@
       "id": "0226773e-b1eb-4e06-a92e-918c375b15a1",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "\n",
-        "USE pdf_db;\n",
-        "SELECT JSON_ARRAY_UNPACK_F32(vector)\n",
-        "FROM pdf_docs1\n",
-        "LIMIT 1;"
-      ]
+      "source": "%%sql\n\nUSE pdf_db;\nSELECT JSON_ARRAY_UNPACK_F32(vector)\nFROM pdf_docs1\nLIMIT 1;"
     },
     {
       "cell_type": "code",
@@ -188,25 +100,7 @@
       "id": "5597f268-7dc2-4453-a5b1-e40fb211d0e8",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "query_text = \"Will object-oriented databases be commercially successful?\"\n",
-        "\n",
-        "query_embedding = embedder.embed_documents([query_text])[0]\n",
-        "\n",
-        "stmt = \"\"\"\n",
-        "    SELECT\n",
-        "        content,\n",
-        "        DOT_PRODUCT_F32(JSON_ARRAY_PACK_F32(%s), vector) AS score\n",
-        "    FROM pdf_docs1\n",
-        "    ORDER BY score DESC\n",
-        "    LIMIT 1\n",
-        "\"\"\"\n",
-        "\n",
-        "results = db_connection.execute(stmt, str(query_embedding))\n",
-        "\n",
-        "for row in results:\n",
-        "    print(row[0])"
-      ]
+      "source": "query_text = \"Will object-oriented databases be commercially successful?\"\n\nquery_embedding = embedder.embed_documents([query_text])[0]\n\nstmt = \"\"\"\n    SELECT\n        content,\n        DOT_PRODUCT_F32(JSON_ARRAY_PACK_F32(%s), vector) AS score\n    FROM pdf_docs1\n    ORDER BY score DESC\n    LIMIT 1\n\"\"\"\n\nresults = db_connection.execute(stmt, str(query_embedding))\n\nfor row in results:\n    print(row[0])"
     },
     {
       "cell_type": "code",
@@ -214,30 +108,13 @@
       "id": "a469ffbd-5084-4c5a-b961-a8c908c391ce",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import openai\n",
-        "\n",
-        "prompt = f\"The user asked: {query_text}. The most similar text from the document is: {row[0]}\"\n",
-        "\n",
-        "response = openai.ChatCompletion.create(\n",
-        "    model=\"gpt-3.5-turbo\",\n",
-        "    messages=[\n",
-        "        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
-        "        {\"role\": \"user\", \"content\": prompt}\n",
-        "    ]\n",
-        ")\n",
-        "\n",
-        "print(response['choices'][0]['message']['content'])"
-      ]
+      "source": "import openai\n\nprompt = f\"The user asked: {query_text}. The most similar text from the document is: {row[0]}\"\n\nresponse = openai.ChatCompletion.create(\n    model=\"gpt-3.5-turbo\",\n    messages=[\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": prompt}\n    ]\n)\n\nprint(response['choices'][0]['message']['content'])"
     },
     {
       "cell_type": "markdown",
       "id": "f1ce8da7-0868-47fd-8585-4777d26f3adc",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -262,7 +139,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/movie-recommendation/notebook.ipynb
+++ b/notebooks/movie-recommendation/notebook.ipynb
@@ -4,39 +4,19 @@
       "cell_type": "markdown",
       "id": "ce06fbf2-db8e-4fb9-9036-40f9ec8c4592",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(255, 182, 176, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/camera-movie.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Movie Recommendation</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(255, 182, 176, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/camera-movie.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Movie Recommendation</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "7ed6450d-8003-47b8-9d31-4ffa221906ae",
       "metadata": {},
-      "source": [
-        "*Source*: [Full MovieLens 25M Dataset](https://grouplens.org/datasets/movielens/25m/)\n",
-        "\n",
-        "This notebook demonstrates how SingleStoreDB helps you build a simple Movie Recommender System.\n",
-        "\n",
-        "<img src=https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/movie-recommendation/images/database-tables.png width=\"1000\">"
-      ]
+      "source": "*Source*: [Full MovieLens 25M Dataset](https://grouplens.org/datasets/movielens/25m/)\n\nThis notebook demonstrates how SingleStoreDB helps you build a simple Movie Recommender System.\n\n<img src=https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/movie-recommendation/images/database-tables.png width=\"1000\">"
     },
     {
       "cell_type": "markdown",
       "id": "f940c981-b378-40cf-bb24-53b6015e486d",
       "metadata": {},
-      "source": [
-        "## 1. Install required libraries\n",
-        "\n",
-        "Install the library for vectorizing the data (up to 2 minutes)."
-      ]
+      "source": "## 1. Install required libraries\n\nInstall the library for vectorizing the data (up to 2 minutes)."
     },
     {
       "cell_type": "code",
@@ -44,245 +24,127 @@
       "id": "4fc72c97-8ba9-462b-b241-ae2ff4e7531c",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip install sentence-transformers --quiet"
-      ]
+      "source": "!pip install sentence-transformers --quiet"
     },
     {
       "cell_type": "markdown",
       "id": "5c9049cb-88b8-411a-b926-2517bd44859e",
       "metadata": {},
-      "source": [
-        "## 2. Create database and ingest data"
-      ]
+      "source": "## 2. Create database and ingest data"
     },
     {
       "cell_type": "markdown",
       "id": "2642c910-72a8-433b-b5fe-e5654f93f239",
       "metadata": {},
-      "source": [
-        "Create the `movie_recommender` database."
-      ]
+      "source": "Create the `movie_recommender` database."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "fd83f672-5ef5-4a8e-9e7a-267dd19815f7",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE IF EXISTS movie_recommender;\n",
-        "\n",
-        "CREATE DATABASE movie_recommender;"
-      ]
+      "source": "DROP DATABASE IF EXISTS movie_recommender;\n\nCREATE DATABASE movie_recommender;"
     },
     {
       "cell_type": "markdown",
       "id": "d6c75b9a-7a1f-44fe-9e25-f67f75c0d11f",
       "metadata": {},
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n",
-        "    <div>\n",
-        "        <p><b>Action Required</b></p>\n",
-        "        <p>Make sure to select the <tt>movie_recommender</tt> database from the drop-down menu at the top of this notebook.\n",
-        "        It updates the <tt>connection_url</tt> which is used by the <tt>%%sql</tt> magic command and SQLAlchemy to make connections to the selected database.</p>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div class=\"alert alert-block alert-warning\">\n    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n    <div>\n        <p><b>Action Required</b></p>\n        <p>Make sure to select the <tt>movie_recommender</tt> database from the drop-down menu at the top of this notebook.\n        It updates the <tt>connection_url</tt> which is used by SQLAlchemy to make connections to the selected database.</p>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "d215945f-3dcf-4e8d-b201-361af227260c",
       "metadata": {},
-      "source": [
-        "Create `tags` table and start pipeline."
-      ]
+      "source": "Create `tags` table and start pipeline."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "f6e6f6d6-87c0-4cf8-9d21-72edf3416e8d",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "CREATE TABLE IF NOT EXISTS tags (\n",
-        "    `userId` bigint(20) NULL,\n",
-        "    `movieId` bigint(20) NULL,\n",
-        "    `tag` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL,\n",
-        "    `timestamp` bigint(20) NULL\n",
-        ");\n",
-        "\n",
-        "CREATE PIPELINE tags\n",
-        "    AS LOAD DATA S3 'studiotutorials/movielens/tags.csv'\n",
-        "    CONFIG '{\\\"region\\\":\\\"us-east-1\\\", \\\"disable_gunzip\\\": false}'\n",
-        "    BATCH_INTERVAL 2500\n",
-        "    MAX_PARTITIONS_PER_BATCH 1\n",
-        "    DISABLE OUT_OF_ORDER OPTIMIZATION\n",
-        "    DISABLE OFFSETS METADATA GC\n",
-        "    SKIP DUPLICATE KEY ERRORS\n",
-        "    INTO TABLE `tags`\n",
-        "    FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '\\\\'\n",
-        "    LINES TERMINATED BY '\\r\\n'\n",
-        "    NULL DEFINED BY ''\n",
-        "    IGNORE 1 LINES\n",
-        "    (userId, movieId, tag, timestamp);\n",
-        "\n",
-        "START PIPELINE tags;"
-      ]
+      "source": "CREATE TABLE IF NOT EXISTS tags (\n    `userId` bigint(20) NULL,\n    `movieId` bigint(20) NULL,\n    `tag` text CHARACTER SET utf8 COLLATE utf8_general_ci NULL,\n    `timestamp` bigint(20) NULL\n);\n\nCREATE PIPELINE tags\n    AS LOAD DATA S3 'studiotutorials/movielens/tags.csv'\n    CONFIG '{\\\"region\\\":\\\"us-east-1\\\", \\\"disable_gunzip\\\": false}'\n    BATCH_INTERVAL 2500\n    MAX_PARTITIONS_PER_BATCH 1\n    DISABLE OUT_OF_ORDER OPTIMIZATION\n    DISABLE OFFSETS METADATA GC\n    SKIP DUPLICATE KEY ERRORS\n    INTO TABLE `tags`\n    FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '\\\\'\n    LINES TERMINATED BY '\\r\\n'\n    NULL DEFINED BY ''\n    IGNORE 1 LINES\n    (userId, movieId, tag, timestamp);\n\nSTART PIPELINE tags;"
     },
     {
       "cell_type": "markdown",
       "id": "a85c13ff-e719-46b4-a781-891d60415ca8",
       "metadata": {},
-      "source": [
-        "Create `ratings` table and start pipeline."
-      ]
+      "source": "Create `ratings` table and start pipeline."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "4c55da7c-fc1e-446c-aa9d-52ee3b085d97",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "CREATE TABLE IF NOT EXISTS ratings (\n",
-        "    userId bigint(20) DEFAULT NULL,\n",
-        "    movieId bigint(20) DEFAULT NULL,\n",
-        "    rating double DEFAULT NULL,\n",
-        "    timestamp bigint(20) DEFAULT NULL\n",
-        ");\n",
-        "\n",
-        "CREATE PIPELINE ratings\n",
-        "    AS LOAD DATA S3 'studiotutorials/movielens/ratings.csv'\n",
-        "    CONFIG '{\\\"region\\\":\\\"us-east-1\\\", \\\"disable_gunzip\\\": false}'\n",
-        "    BATCH_INTERVAL 2500\n",
-        "    MAX_PARTITIONS_PER_BATCH 1\n",
-        "    DISABLE OUT_OF_ORDER OPTIMIZATION\n",
-        "    DISABLE OFFSETS METADATA GC\n",
-        "    SKIP DUPLICATE KEY ERRORS\n",
-        "    INTO TABLE `ratings`\n",
-        "    FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '\\\\'\n",
-        "    LINES TERMINATED BY '\\r\\n'\n",
-        "    NULL DEFINED BY ''\n",
-        "    IGNORE 1 LINES\n",
-        "    (userId, movieId, rating, timestamp);\n",
-        "\n",
-        "START PIPELINE ratings;"
-      ]
+      "source": "CREATE TABLE IF NOT EXISTS ratings (\n    userId bigint(20) DEFAULT NULL,\n    movieId bigint(20) DEFAULT NULL,\n    rating double DEFAULT NULL,\n    timestamp bigint(20) DEFAULT NULL\n);\n\nCREATE PIPELINE ratings\n    AS LOAD DATA S3 'studiotutorials/movielens/ratings.csv'\n    CONFIG '{\\\"region\\\":\\\"us-east-1\\\", \\\"disable_gunzip\\\": false}'\n    BATCH_INTERVAL 2500\n    MAX_PARTITIONS_PER_BATCH 1\n    DISABLE OUT_OF_ORDER OPTIMIZATION\n    DISABLE OFFSETS METADATA GC\n    SKIP DUPLICATE KEY ERRORS\n    INTO TABLE `ratings`\n    FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '\\\\'\n    LINES TERMINATED BY '\\r\\n'\n    NULL DEFINED BY ''\n    IGNORE 1 LINES\n    (userId, movieId, rating, timestamp);\n\nSTART PIPELINE ratings;"
     },
     {
       "cell_type": "markdown",
       "id": "e79e99ac-190b-481c-bf8f-7d66265fba81",
       "metadata": {},
-      "source": [
-        "Create `movies` table and start pipeline."
-      ]
+      "source": "Create `movies` table and start pipeline."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "fba97ca5-3673-4ce8-b6f7-3214f6205bd9",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "CREATE TABLE movies (\n",
-        "    movieId bigint(20) DEFAULT NULL,\n",
-        "    title text CHARACTER SET utf8 COLLATE utf8_general_ci,\n",
-        "    genres text CHARACTER SET utf8 COLLATE utf8_general_ci,\n",
-        "    FULLTEXT(title)\n",
-        ");\n",
-        "\n",
-        "CREATE PIPELINE movies\n",
-        "    AS LOAD DATA S3 'studiotutorials/movielens/movies.csv'\n",
-        "    CONFIG '{\\\"region\\\":\\\"us-east-1\\\", \\\"disable_gunzip\\\": false}'\n",
-        "    BATCH_INTERVAL 2500\n",
-        "    MAX_PARTITIONS_PER_BATCH 1\n",
-        "    DISABLE OUT_OF_ORDER OPTIMIZATION\n",
-        "    DISABLE OFFSETS METADATA GC\n",
-        "    SKIP DUPLICATE KEY ERRORS\n",
-        "    INTO TABLE `movies`\n",
-        "    FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '\\\\'\n",
-        "    LINES TERMINATED BY '\\r\\n'\n",
-        "    NULL DEFINED BY ''\n",
-        "    IGNORE 1 LINES\n",
-        "    (movieId, title, genres);\n",
-        "\n",
-        "START PIPELINE movies;"
-      ]
+      "source": "CREATE TABLE movies (\n    movieId bigint(20) DEFAULT NULL,\n    title text CHARACTER SET utf8 COLLATE utf8_general_ci,\n    genres text CHARACTER SET utf8 COLLATE utf8_general_ci,\n    FULLTEXT(title)\n);\n\nCREATE PIPELINE movies\n    AS LOAD DATA S3 'studiotutorials/movielens/movies.csv'\n    CONFIG '{\\\"region\\\":\\\"us-east-1\\\", \\\"disable_gunzip\\\": false}'\n    BATCH_INTERVAL 2500\n    MAX_PARTITIONS_PER_BATCH 1\n    DISABLE OUT_OF_ORDER OPTIMIZATION\n    DISABLE OFFSETS METADATA GC\n    SKIP DUPLICATE KEY ERRORS\n    INTO TABLE `movies`\n    FIELDS TERMINATED BY ',' ENCLOSED BY '\"' ESCAPED BY '\\\\'\n    LINES TERMINATED BY '\\r\\n'\n    NULL DEFINED BY ''\n    IGNORE 1 LINES\n    (movieId, title, genres);\n\nSTART PIPELINE movies;"
     },
     {
       "cell_type": "markdown",
       "id": "6e41ed09-2cc3-4fb7-90da-077a04111417",
       "metadata": {},
-      "source": [
-        "### Check that all the data has been loaded\n",
-        "\n",
-        "There should be 25m rows for ratings, 62k for movies and 1m for tags. If the values are less than that, try the query\n",
-        "again in a few seconds, the pipelines are still running."
-      ]
+      "source": "### Check that all the data has been loaded\n\nThere should be 25m rows for ratings, 62k for movies and 1m for tags. If the values are less than that, try the query\nagain in a few seconds, the pipelines are still running."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "cf4c1d0f-8de2-42ea-ab33-7dadbde74855",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "SELECT COUNT(*) AS count_rows FROM ratings\n",
-        "UNION ALL\n",
-        "SELECT COUNT(*) AS count_rows FROM movies\n",
-        "UNION ALL\n",
-        "SELECT COUNT(*) AS count_rows FROM tags"
-      ]
+      "source": "SELECT COUNT(*) AS count_rows FROM ratings\nUNION ALL\nSELECT COUNT(*) AS count_rows FROM movies\nUNION ALL\nSELECT COUNT(*) AS count_rows FROM tags"
     },
     {
       "cell_type": "markdown",
       "id": "0fb4162d-a55a-4926-9ce0-500d5909e3a2",
       "metadata": {},
-      "source": [
-        "### Concatenate `tags` and `movies` tables using all tags"
-      ]
+      "source": "### Concatenate `tags` and `movies` tables using all tags"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "17be3378-28ea-4487-9177-a266d0998a08",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "CREATE TABLE movies_with_tags AS\n",
-        "    SELECT \n",
-        "        m.movieId, \n",
-        "        m.title, \n",
-        "        m.genres,\n",
-        "        GROUP_CONCAT(t.tag SEPARATOR ',') AS all_tags\n",
-        "    FROM movies m\n",
-        "    LEFT JOIN tags t ON m.movieId = t.movieId\n",
-        "    GROUP BY m.movieId, m.title, m.genres;"
-      ]
+      "source": "CREATE TABLE movies_with_tags AS\n    SELECT \n        m.movieId, \n        m.title, \n        m.genres,\n        GROUP_CONCAT(t.tag SEPARATOR ',') AS all_tags\n    FROM movies m\n    LEFT JOIN tags t ON m.movieId = t.movieId\n    GROUP BY m.movieId, m.title, m.genres;"
     },
     {
       "cell_type": "markdown",
       "id": "f4f2be44-5c5d-4113-9b9e-55bfa89d5d5b",
       "metadata": {},
-      "source": [
-        "## 3. Vectorize data"
-      ]
+      "source": "## 3. Vectorize data"
     },
     {
       "cell_type": "markdown",
       "id": "f300136e-2a85-4095-867d-7723b3d61b2d",
       "metadata": {},
-      "source": [
-        "Initialize sentence transformer."
-      ]
+      "source": "Initialize sentence transformer."
     },
     {
       "cell_type": "code",
@@ -290,39 +152,30 @@
       "id": "204c4a32-bafd-45d7-928e-3ec1083b4b58",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "from sentence_transformers import SentenceTransformer\n",
-        "\n",
-        "model = SentenceTransformer('flax-sentence-embeddings/all_datasets_v3_mpnet-base')"
-      ]
+      "source": "from sentence_transformers import SentenceTransformer\n\nmodel = SentenceTransformer('flax-sentence-embeddings/all_datasets_v3_mpnet-base')"
     },
     {
       "cell_type": "markdown",
       "id": "fce95741-8094-4a4b-8a4a-f92699471da5",
       "metadata": {},
-      "source": [
-        "Query the `movies_with_tags` table and store the output in a variable named `result`. The `result <<` syntax in the \n",
-        "`%%sql` line indicates that the output from the query should get stored under that variable name."
-      ]
+      "source": "Query the `movies_with_tags` table and store the output in a variable named `result`. By setting an output variable the output from the query will get stored under that variable name."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "920798f0-55b6-4f2d-ba36-7f94e750f684",
-      "metadata": {},
+      "metadata": {
+        "language": "sql",
+        "output_variable": "result"
+      },
       "outputs": [],
-      "source": [
-        "%%sql result <<\n",
-        "SELECT * FROM movies_with_tags"
-      ]
+      "source": "SELECT * FROM movies_with_tags"
     },
     {
       "cell_type": "markdown",
       "id": "08651421-7313-4bb5-87f1-56ea165d45c5",
       "metadata": {},
-      "source": [
-        "Convert the result from the above SQL into a DataFrame and clean up quotes."
-      ]
+      "source": "Convert the result from the above SQL into a DataFrame and clean up quotes."
     },
     {
       "cell_type": "code",
@@ -330,26 +183,13 @@
       "id": "01d5cf58-65eb-4676-90b9-0d5a9253fd34",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import pandas as pd\n",
-        "\n",
-        "df = pd.DataFrame(result)\n",
-        "\n",
-        "# Curate the special characters\n",
-        "df['title'] = df['title'].str.replace('\"', '')\n",
-        "df['all_tags'] = df['all_tags'].str.replace('\"', '').str.replace(\"'\", '')\n",
-        "\n",
-        "# Convert from dataframe to list\n",
-        "all_titles = df.values.tolist()"
-      ]
+      "source": "import pandas as pd\n\ndf = pd.DataFrame(result)\n\n# Curate the special characters\ndf['title'] = df['title'].str.replace('\"', '')\ndf['all_tags'] = df['all_tags'].str.replace('\"', '').str.replace(\"'\", '')\n\n# Convert from dataframe to list\nall_titles = df.values.tolist()"
     },
     {
       "cell_type": "markdown",
       "id": "134caeab-a430-4412-91d7-d74b3dd0002b",
       "metadata": {},
-      "source": [
-        "Check the first row of the list."
-      ]
+      "source": "Check the first row of the list."
     },
     {
       "cell_type": "code",
@@ -357,17 +197,13 @@
       "id": "de9b96b6-0fb3-47f9-8186-b5e6cee330a4",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "all_titles[0]"
-      ]
+      "source": "all_titles[0]"
     },
     {
       "cell_type": "markdown",
       "id": "6b88c557-44b5-4d48-b314-c50d65a4e5d5",
       "metadata": {},
-      "source": [
-        "Concatenate title and tags."
-      ]
+      "source": "Concatenate title and tags."
     },
     {
       "cell_type": "code",
@@ -375,17 +211,13 @@
       "id": "a1d9b7f5-409c-4053-a724-39747ce663b8",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "all_title_type_column = [f'{row[1]}-{row[3]}' if row[1] is not None else row[1] for row in all_titles]"
-      ]
+      "source": "all_title_type_column = [f'{row[1]}-{row[3]}' if row[1] is not None else row[1] for row in all_titles]"
     },
     {
       "cell_type": "markdown",
       "id": "77af8001-a7d5-4a24-8290-b025d00ca1f3",
       "metadata": {},
-      "source": [
-        "Create the embeddings for Title & Tag (~3 minutes)."
-      ]
+      "source": "Create the embeddings for Title & Tag (~3 minutes)."
     },
     {
       "cell_type": "code",
@@ -393,19 +225,13 @@
       "id": "efd8aaa2-feaf-43ce-9f72-f5161d781f00",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "# Remove [:3000] if you want to vectorize all rows (~60 minutes)\n",
-        "all_embeddings = model.encode(all_title_type_column[:3000])\n",
-        "all_embeddings.shape"
-      ]
+      "source": "# Remove [:3000] if you want to vectorize all rows (~60 minutes)\nall_embeddings = model.encode(all_title_type_column[:3000])\nall_embeddings.shape"
     },
     {
       "cell_type": "markdown",
       "id": "1e59050c-d53c-476f-a4cb-ce97f759efa0",
       "metadata": {},
-      "source": [
-        "Join the original data with the vector data."
-      ]
+      "source": "Join the original data with the vector data."
     },
     {
       "cell_type": "code",
@@ -413,48 +239,29 @@
       "id": "54b0546d-0e22-4fde-a903-18c714bdd21d",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "# Remember the list will be only 3,000 elements\n",
-        "combined_data = [tuple(row) + (embedding,) for embedding, row in zip(all_embeddings, all_titles)]"
-      ]
+      "source": "# Remember the list will be only 3,000 elements\ncombined_data = [tuple(row) + (embedding,) for embedding, row in zip(all_embeddings, all_titles)]"
     },
     {
       "cell_type": "markdown",
       "id": "f482feed-edd4-4489-8ab4-cdd5803515f3",
       "metadata": {},
-      "source": [
-        "## 4. Create table for movie information and vectors"
-      ]
+      "source": "## 4. Create table for movie information and vectors"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "32f4d535-8ea6-47a9-9fd3-5215a23f72e3",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP TABLE IF EXISTS movie_with_tags_with_vectors;\n",
-        "\n",
-        "CREATE TABLE movie_with_tags_with_vectors (\n",
-        "    movieId bigint(20) DEFAULT NULL,\n",
-        "    title text CHARACTER SET utf8 COLLATE utf8_general_ci,\n",
-        "    genres text CHARACTER SET utf8 COLLATE utf8_general_ci,\n",
-        "    all_tags longtext CHARACTER SET utf8mb4,\n",
-        "    vector blob\n",
-        ")"
-      ]
+      "source": "DROP TABLE IF EXISTS movie_with_tags_with_vectors;\n\nCREATE TABLE movie_with_tags_with_vectors (\n    movieId bigint(20) DEFAULT NULL,\n    title text CHARACTER SET utf8 COLLATE utf8_general_ci,\n    genres text CHARACTER SET utf8 COLLATE utf8_general_ci,\n    all_tags longtext CHARACTER SET utf8mb4,\n    vector blob\n)"
     },
     {
       "cell_type": "markdown",
       "id": "23570610-0ec1-4c3c-a63b-8221130042cf",
       "metadata": {},
-      "source": [
-        "Create a database connection using SQLAlchemy. We are going to use an SQLAlchemy connection here because one\n",
-        "column of data is numpy arrays. The SingleStoreDB SQLAlchemy driver will automatically convert those to\n",
-        "the correct binary format when uploading, so it's a bit more convenient than doing the conversions and \n",
-        "formatting manually for the `%sql` magic command."
-      ]
+      "source": "Create a database connection using SQLAlchemy. We are going to use an SQLAlchemy connection here because one\ncolumn of data is numpy arrays. The SingleStoreDB SQLAlchemy driver will automatically convert those to\nthe correct binary format when uploading, so it's a bit more convenient than doing the conversions and \nformatting manually in SQL."
     },
     {
       "cell_type": "code",
@@ -462,19 +269,13 @@
       "id": "46c50550-5961-45df-ace8-65d7b91edc42",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "from singlestoredb import create_engine\n",
-        "\n",
-        "db_connection = create_engine().connect()"
-      ]
+      "source": "from singlestoredb import create_engine\n\ndb_connection = create_engine().connect()"
     },
     {
       "cell_type": "markdown",
       "id": "db42c917-2d53-46c8-96b5-55d7e8b4d327",
       "metadata": {},
-      "source": [
-        "Insert the data. Some rows might encounter errors due to unsupported characters."
-      ]
+      "source": "Insert the data. Some rows might encounter errors due to unsupported characters."
     },
     {
       "cell_type": "code",
@@ -482,208 +283,89 @@
       "id": "4cbf8232-7738-49fa-be00-1e7a5f1882b3",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "sql_query = 'INSERT INTO movie_with_tags_with_vectors (movieId, title, genres, all_tags, vector) VALUES (%s, %s, %s, %s, %s)'\n",
-        "\n",
-        "for i, row in enumerate(combined_data):\n",
-        "    try:\n",
-        "        db_connection.execute(sql_query, row)\n",
-        "    except Exception as e:\n",
-        "        print(\"Error inserting row {}: {}\".format(i, e))\n",
-        "        continue"
-      ]
+      "source": "sql_query = 'INSERT INTO movie_with_tags_with_vectors (movieId, title, genres, all_tags, vector) VALUES (%s, %s, %s, %s, %s)'\n\nfor i, row in enumerate(combined_data):\n    try:\n        db_connection.execute(sql_query, row)\n    except Exception as e:\n        print(\"Error inserting row {}: {}\".format(i, e))\n        continue"
     },
     {
       "cell_type": "markdown",
       "id": "192353be-db56-4cec-8d6e-a258532c6dd9",
       "metadata": {},
-      "source": [
-        "## 5. Marrying Search \u2764\ufe0f Semantic Search \u2764\ufe0f Analytics"
-      ]
+      "source": "## 5. Marrying Search ❤️ Semantic Search ❤️ Analytics"
     },
     {
       "cell_type": "markdown",
       "id": "edd2d5e9-b4ad-4d10-b638-eabeaaad4846",
       "metadata": {},
-      "source": [
-        "### Build autocomplete search"
-      ]
+      "source": "### Build autocomplete search"
     },
     {
       "cell_type": "markdown",
       "id": "26e07b98-b934-42b9-935c-1e9d750b7697",
       "metadata": {},
-      "source": [
-        "This is en experimentat we started with to render a full text search."
-      ]
+      "source": "This is en experimentat we started with to render a full text search."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "eca42fb8-2591-472b-a607-85c5fb3d5f63",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "WITH queryouter AS (\n",
-        "                SELECT DISTINCT(title), movieId, MATCH(title) AGAINST ('Pocahontas*') as relevance\n",
-        "                FROM movies\n",
-        "                WHERE MATCH(title) AGAINST ('Pocahontas*')\n",
-        "                ORDER BY relevance DESC\n",
-        "                LIMIT 10)\n",
-        "    SELECT title, movieId FROM queryouter;"
-      ]
+      "source": "WITH queryouter AS (\n                SELECT DISTINCT(title), movieId, MATCH(title) AGAINST ('Pocahontas*') as relevance\n                FROM movies\n                WHERE MATCH(title) AGAINST ('Pocahontas*')\n                ORDER BY relevance DESC\n                LIMIT 10)\n    SELECT title, movieId FROM queryouter;"
     },
     {
       "cell_type": "markdown",
       "id": "9f4d78ba-a0ad-4a4c-98e7-f06ce1281ed1",
       "metadata": {},
-      "source": [
-        "### Create user favorite movie tables"
-      ]
+      "source": "### Create user favorite movie tables"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "45a78f0a-c6bd-423b-bc5e-df641c78f48e",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "CREATE ROWSTORE TABLE IF NOT EXISTS user_choice (\n",
-        "    userid text CHARACTER SET utf8 COLLATE utf8_general_ci,\n",
-        "    title text CHARACTER SET utf8 COLLATE utf8_general_ci,\n",
-        "    ts datetime DEFAULT NULL,\n",
-        "    KEY userid (userid)\n",
-        ")"
-      ]
+      "source": "CREATE ROWSTORE TABLE IF NOT EXISTS user_choice (\n    userid text CHARACTER SET utf8 COLLATE utf8_general_ci,\n    title text CHARACTER SET utf8 COLLATE utf8_general_ci,\n    ts datetime DEFAULT NULL,\n    KEY userid (userid)\n)"
     },
     {
       "cell_type": "markdown",
       "id": "b6f053f4-5654-48d0-b897-9dfb1aaff016",
       "metadata": {},
-      "source": [
-        "Enter dummy data for testing purposes."
-      ]
+      "source": "Enter dummy data for testing purposes."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "98ca4b36-3aa0-43d9-8e9f-ffb9f08e9b72",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "INSERT INTO user_choice (userid, title, ts)\n",
-        "    VALUES ('user1', 'Zone 39 (1997)', '2022-01-01 00:00:00'),\n",
-        "           ('user1', 'Star Trek II: The Wrath of Khan (1982)', '2022-01-01 00:00:00'),\n",
-        "           ('user1', 'Giver, The (2014)', '2022-01-01 00:00:00');"
-      ]
+      "source": "INSERT INTO user_choice (userid, title, ts)\n    VALUES ('user1', 'Zone 39 (1997)', '2022-01-01 00:00:00'),\n           ('user1', 'Star Trek II: The Wrath of Khan (1982)', '2022-01-01 00:00:00'),\n           ('user1', 'Giver, The (2014)', '2022-01-01 00:00:00');"
     },
     {
       "cell_type": "markdown",
       "id": "cbe64201-0260-43be-87c0-20616c34ce59",
       "metadata": {},
-      "source": [
-        "### Build semantic search for a movie recommendation"
-      ]
+      "source": "### Build semantic search for a movie recommendation"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "c2368b35-e2cd-4a7c-82a5-565cabc73f90",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "WITH\n",
-        "    table_match AS (\n",
-        "        SELECT\n",
-        "            m.title,\n",
-        "            m.movieId,\n",
-        "            m.vector\n",
-        "        FROM\n",
-        "            user_choice t\n",
-        "            INNER JOIN movie_with_tags_with_vectors m ON m.title = t.title\n",
-        "        WHERE\n",
-        "            userid = 'user1'\n",
-        "    ),\n",
-        "    movie_pairs AS (\n",
-        "        SELECT\n",
-        "            m1.movieId AS movieId1,\n",
-        "            m1.title AS title1,\n",
-        "            m2.movieId AS movieId2,\n",
-        "            m2.title AS title2,\n",
-        "            DOT_PRODUCT(m1.vector, m2.vector) AS similarity\n",
-        "        FROM\n",
-        "            table_match m1\n",
-        "            CROSS JOIN movie_with_tags_with_vectors m2\n",
-        "        WHERE\n",
-        "            m1.movieId != m2.movieId\n",
-        "            AND NOT EXISTS (\n",
-        "                SELECT\n",
-        "                    1\n",
-        "                FROM\n",
-        "                    user_choice uc\n",
-        "                WHERE\n",
-        "                    uc.userid = 'user1'\n",
-        "                    AND uc.title = m2.title\n",
-        "            )\n",
-        "    ),\n",
-        "    movie_match AS (\n",
-        "        SELECT\n",
-        "            movieId1,\n",
-        "            title1,\n",
-        "            movieId2,\n",
-        "            title2,\n",
-        "            similarity\n",
-        "        FROM\n",
-        "            movie_pairs\n",
-        "        ORDER BY\n",
-        "            similarity DESC\n",
-        "    ),\n",
-        "    distinct_count AS (\n",
-        "        SELECT DISTINCT\n",
-        "            movieId2,\n",
-        "            title2 AS Title,\n",
-        "            ROUND(AVG(similarity), 4) AS Rating_Match\n",
-        "        FROM\n",
-        "            movie_match\n",
-        "        GROUP BY\n",
-        "            movieId2,\n",
-        "            title2\n",
-        "        ORDER BY\n",
-        "            Rating_Match DESC\n",
-        "    ),\n",
-        "    average_ratings AS (\n",
-        "        SELECT\n",
-        "            movieId,\n",
-        "            AVG(rating) AS Avg_Rating\n",
-        "        FROM\n",
-        "            ratings\n",
-        "        GROUP BY\n",
-        "            movieId\n",
-        "    )\n",
-        "SELECT\n",
-        "    dc.Title,\n",
-        "    dc.Rating_Match as 'Match Score',\n",
-        "    ROUND(ar.Avg_Rating, 1) AS 'Average User Rating'\n",
-        "FROM\n",
-        "    distinct_count dc\n",
-        "    JOIN average_ratings ar ON dc.movieId2 = ar.movieId\n",
-        "ORDER BY\n",
-        "    dc.Rating_Match DESC\n",
-        "LIMIT\n",
-        "    5;"
-      ]
+      "source": "WITH\n    table_match AS (\n        SELECT\n            m.title,\n            m.movieId,\n            m.vector\n        FROM\n            user_choice t\n            INNER JOIN movie_with_tags_with_vectors m ON m.title = t.title\n        WHERE\n            userid = 'user1'\n    ),\n    movie_pairs AS (\n        SELECT\n            m1.movieId AS movieId1,\n            m1.title AS title1,\n            m2.movieId AS movieId2,\n            m2.title AS title2,\n            DOT_PRODUCT(m1.vector, m2.vector) AS similarity\n        FROM\n            table_match m1\n            CROSS JOIN movie_with_tags_with_vectors m2\n        WHERE\n            m1.movieId != m2.movieId\n            AND NOT EXISTS (\n                SELECT\n                    1\n                FROM\n                    user_choice uc\n                WHERE\n                    uc.userid = 'user1'\n                    AND uc.title = m2.title\n            )\n    ),\n    movie_match AS (\n        SELECT\n            movieId1,\n            title1,\n            movieId2,\n            title2,\n            similarity\n        FROM\n            movie_pairs\n        ORDER BY\n            similarity DESC\n    ),\n    distinct_count AS (\n        SELECT DISTINCT\n            movieId2,\n            title2 AS Title,\n            ROUND(AVG(similarity), 4) AS Rating_Match\n        FROM\n            movie_match\n        GROUP BY\n            movieId2,\n            title2\n        ORDER BY\n            Rating_Match DESC\n    ),\n    average_ratings AS (\n        SELECT\n            movieId,\n            AVG(rating) AS Avg_Rating\n        FROM\n            ratings\n        GROUP BY\n            movieId\n    )\nSELECT\n    dc.Title,\n    dc.Rating_Match as 'Match Score',\n    ROUND(ar.Avg_Rating, 1) AS 'Average User Rating'\nFROM\n    distinct_count dc\n    JOIN average_ratings ar ON dc.movieId2 = ar.movieId\nORDER BY\n    dc.Rating_Match DESC\nLIMIT\n    5;"
     },
     {
       "cell_type": "markdown",
       "id": "3a9efa4a-1a38-49f3-ba6d-a00b6c90e2b0",
       "metadata": {},
-      "source": [
-        "## 6. What are you looking for?"
-      ]
+      "source": "## 6. What are you looking for?"
     },
     {
       "cell_type": "code",
@@ -691,9 +373,7 @@
       "id": "87547d68-e1c9-4fd8-946f-6b378c9b36f2",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "search_embedding = model.encode(\"I want see a French comedy movie\")"
-      ]
+      "source": "search_embedding = model.encode(\"I want see a French comedy movie\")"
     },
     {
       "cell_type": "code",
@@ -701,33 +381,13 @@
       "id": "3b70a678-4829-4456-8946-d1dcbf46c98b",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "sql_query = \"SELECT title, genres, DOT_PRODUCT(vector, %(vector)s) AS Score FROM movie_with_tags_with_vectors tv \" + \\\n",
-        "            \"ORDER BY Score DESC \" + \\\n",
-        "            \"LIMIT 10\"\n",
-        "\n",
-        "results = db_connection.execute(sql_query, dict(vector=search_embedding))\n",
-        "\n",
-        "output_list = []\n",
-        "for res in results:\n",
-        "    output_list.append({\n",
-        "        'title': res[0],\n",
-        "        'genres': res[1],\n",
-        "        'score': res[2]\n",
-        "    })\n",
-        "\n",
-        "for i, res in enumerate(output_list):\n",
-        "    print(f\"{i + 1}: {res['title']} {res['genres']} Score: {res['score']}\")"
-      ]
+      "source": "sql_query = \"SELECT title, genres, DOT_PRODUCT(vector, %(vector)s) AS Score FROM movie_with_tags_with_vectors tv \" + \\\n            \"ORDER BY Score DESC \" + \\\n            \"LIMIT 10\"\n\nresults = db_connection.execute(sql_query, dict(vector=search_embedding))\n\noutput_list = []\nfor res in results:\n    output_list.append({\n        'title': res[0],\n        'genres': res[1],\n        'score': res[2]\n    })\n\nfor i, res in enumerate(output_list):\n    print(f\"{i + 1}: {res['title']} {res['genres']} Score: {res['score']}\")"
     },
     {
       "cell_type": "markdown",
       "id": "0017d0c2-6647-431d-a937-85132af15b1a",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -746,7 +406,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/movie-recommendation/notebook.ipynb
+++ b/notebooks/movie-recommendation/notebook.ipynb
@@ -289,7 +289,7 @@
       "cell_type": "markdown",
       "id": "192353be-db56-4cec-8d6e-a258532c6dd9",
       "metadata": {},
-      "source": "## 5. Marrying Search ❤️ Semantic Search ❤️ Analytics"
+      "source": "## 5. Marrying Search \u2764\ufe0f Semantic Search \u2764\ufe0f Analytics"
     },
     {
       "cell_type": "markdown",

--- a/notebooks/notebook-basics/notebook.ipynb
+++ b/notebooks/notebook-basics/notebook.ipynb
@@ -51,8 +51,7 @@
       "execution_count": null,
       "id": "22b88c07-c956-4a77-944d-4aac485c1514",
       "metadata": {
-        "language": "sql",
-        "execution": {}
+        "language": "sql"
       },
       "outputs": [],
       "source": "USE information_schema;\n\nSELECT * FROM users\n    LIMIT 3;"

--- a/notebooks/notebook-basics/notebook.ipynb
+++ b/notebooks/notebook-basics/notebook.ipynb
@@ -4,137 +4,86 @@
       "cell_type": "markdown",
       "id": "7e127046-57ff-4259-88eb-94596d9b4c6c",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(209, 153, 255, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/notes.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">SingleStoreDB Notebook Basics</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(209, 153, 255, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/notes.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">SingleStoreDB Notebook Basics</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "680677eb-d3b7-460a-8ac2-94e9a68c8f43",
       "metadata": {},
-      "source": [
-        "Prototyping applications or analyzing datasets using notebooks in SingleStoreDB Cloud follows the same general principles as developing with a Jupyter Notebook. SingleStoreDB Cloud supports internal and external datasources. Internal datasources are databases that exist within your workspace. An external datasource could be an AWS S3 bucket for example. In this Notebook we cover:\n",
-        "\n",
-        "1. Connecting to a SingleStoreDB instance\n",
-        "2. Connecting to an external datasource including firewall Settings\n",
-        "3. Using SQL in a cell\n",
-        "4. Using Python in a cell\n",
-        "5. Using both SQL & Python\n",
-        "6. Installing Libraries\n",
-        "7. Using Magic Commands \n",
-        "\n",
-        "*To learn more about working with SingleStoreDB notebooks check out our [docs](https://docs.singlestore.com/managed-service/en/developer-resources/notebooks.html)!*"
-      ]
+      "source": "Prototyping applications or analyzing datasets using notebooks in SingleStoreDB Cloud follows the same general principles as developing with a Jupyter Notebook. SingleStoreDB Cloud supports internal and external datasources. Internal datasources are databases that exist within your workspace. An external datasource could be an AWS S3 bucket for example. In this Notebook we cover:\n\n1. Connecting to a SingleStoreDB instance\n2. Connecting to an external datasource including firewall Settings\n3. Using SQL in a cell\n4. Using Python in a cell\n5. Using both SQL & Python\n6. Installing Libraries\n7. Using Magic Commands \n\n*To learn more about working with SingleStoreDB notebooks check out our [docs](https://docs.singlestore.com/managed-service/en/developer-resources/notebooks.html)!*"
     },
     {
       "cell_type": "markdown",
       "id": "cb310396-93ad-4c04-b64d-9601b8a202bc",
       "metadata": {},
-      "source": [
-        "## 1. Connecting to SingleStoreDB\n",
-        "\n",
-        "Once you select a workspace, you can access all of the databases attached to that workspace. You cannot connect to databases that are not attached to the workspace you are using."
-      ]
+      "source": "## 1. Connecting to SingleStoreDB\n\nOnce you select a workspace, you can access all of the databases attached to that workspace. You cannot connect to databases that are not attached to the workspace you are using."
     },
     {
       "cell_type": "markdown",
       "id": "8c502a67-9e8e-43b8-8bc6-41df4d5835da",
       "metadata": {},
-      "source": [
-        "First select a workspace and the `information_schema` database from the drop-down menu at the top of this notebook.\n",
-        "\n",
-        "<img src=https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/notebook-basics/images/select-workspace-and-database.png style=\"width: 500px; border: 1px solid darkorchid\"/>"
-      ]
+      "source": "First select a workspace and the `information_schema` database from the drop-down menu at the top of this notebook.\n\n<img src=https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/notebook-basics/images/select-workspace-and-database.png style=\"width: 500px; border: 1px solid darkorchid\"/>"
     },
     {
       "cell_type": "markdown",
       "id": "886169b5-d60f-4669-9d34-20c14e9aba40",
       "metadata": {},
-      "source": [
-        "With the database selected, the `connection_url` variable in the Python enviroment is now updated with that information\n",
-        "and we can use the `%%sql` magic command to query the selected database."
-      ]
+      "source": "With the database selected, the `connection_url` variable in the Python enviroment is now updated with that information\nand we can write in a SQL cell to query the selected database."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "146c9641-23ec-4570-8466-14d2880c66f0",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "SELECT * FROM users\n",
-        "    LIMIT 3;"
-      ]
+      "source": "SELECT * FROM users\n    LIMIT 3;"
     },
     {
       "cell_type": "markdown",
       "id": "8cb9cb0f-c301-4cef-9f19-e86db0e52f73",
       "metadata": {},
-      "source": [
-        "When running SQL commands against a different database explicitly, you can specify the database in your \n",
-        "SQL code with the `USE` command:"
-      ]
+      "source": "When running SQL commands against a different database explicitly, you can specify the database in your \nSQL code with the `USE` command:"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "22b88c07-c956-4a77-944d-4aac485c1514",
-      "metadata": {},
+      "metadata": {
+        "language": "sql",
+        "execution": {}
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "USE information_schema;\n",
-        "\n",
-        "SELECT * FROM users\n",
-        "    LIMIT 3;"
-      ]
+      "source": "USE information_schema;\n\nSELECT * FROM users\n    LIMIT 3;"
     },
     {
       "cell_type": "markdown",
       "id": "e8b06918-25d2-40e6-9ad9-3e8c558e89e9",
       "metadata": {},
-      "source": [
-        "Alternatively, you can specify the database prefix on the table in the query itself."
-      ]
+      "source": "Alternatively, you can specify the database prefix on the table in the query itself."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "8ab697a9-3b41-4f92-8b88-65717d7a4202",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "SELECT * FROM information_schema.users\n",
-        "    LIMIT 3;"
-      ]
+      "source": "SELECT * FROM information_schema.users\n    LIMIT 3;"
     },
     {
       "cell_type": "markdown",
       "id": "3aff8361-669b-474d-a45a-6345de985757",
       "metadata": {},
-      "source": [
-        "## Connecting with SQLAlchemy"
-      ]
+      "source": "## Connecting with SQLAlchemy"
     },
     {
       "cell_type": "markdown",
       "id": "c21cdbb8-c77e-4e31-a584-ff922620fb58",
       "metadata": {},
-      "source": [
-        "You can also connect to your SingleStoreDB datasource using Python and SQLAlchemy. As mentioned above, \n",
-        "the `connection_url` variable is automatically populated by the notebook environment when selecting a\n",
-        "database in the drop-down menu at the top of the notebook."
-      ]
+      "source": "You can also connect to your SingleStoreDB datasource using Python and SQLAlchemy. As mentioned above, \nthe `connection_url` variable is automatically populated by the notebook environment when selecting a\ndatabase in the drop-down menu at the top of the notebook."
     },
     {
       "cell_type": "code",
@@ -142,19 +91,13 @@
       "id": "3e2781f6-626d-4f0d-a5bb-828537c9e6e1",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import sqlalchemy as sa\n",
-        "\n",
-        "db_connection = sa.create_engine(connection_url).connect()"
-      ]
+      "source": "import sqlalchemy as sa\n\ndb_connection = sa.create_engine(connection_url).connect()"
     },
     {
       "cell_type": "markdown",
       "id": "1cae1a31-08c6-44b4-99c8-0d0a1b8b5ff8",
       "metadata": {},
-      "source": [
-        "You can also explicitly define a URL using the individual connection components."
-      ]
+      "source": "You can also explicitly define a URL using the individual connection components."
     },
     {
       "cell_type": "code",
@@ -162,22 +105,13 @@
       "id": "93f26bcd-d07d-48a9-9f7a-edc2f9431c09",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "database_name = \"information_schema\"\n",
-        "\n",
-        "connection_url2 = f\"singlestoredb://{connection_user}:{connection_password}@{connection_host}:{connection_port}/{database_name}\"\n",
-        "\n",
-        "db_connection2 = sa.create_engine(connection_url2).connect()"
-      ]
+      "source": "database_name = \"information_schema\"\n\nconnection_url2 = f\"singlestoredb://{connection_user}:{connection_password}@{connection_host}:{connection_port}/{database_name}\"\n\ndb_connection2 = sa.create_engine(connection_url2).connect()"
     },
     {
       "cell_type": "markdown",
       "id": "082e240d-9480-46a2-a7da-33508423b8e9",
       "metadata": {},
-      "source": [
-        "In addition, the SingleStoreDB Python package includes a wrapper `create_engine` function that \n",
-        "uses the `SINGLESTOREDB_URL` without having to specify `connection_url`."
-      ]
+      "source": "In addition, the SingleStoreDB Python package includes a wrapper `create_engine` function that \nuses the `SINGLESTOREDB_URL` without having to specify `connection_url`."
     },
     {
       "cell_type": "code",
@@ -185,19 +119,13 @@
       "id": "4ec8e9a0-b45a-4f6f-b3a5-7b51a5a89ed0",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import singlestoredb as s2\n",
-        "\n",
-        "db_connection = s2.create_engine().connect()"
-      ]
+      "source": "import singlestoredb as s2\n\ndb_connection = s2.create_engine().connect()"
     },
     {
       "cell_type": "markdown",
       "id": "2dbc2854-2396-49e0-ae9f-5e68cc1e316c",
       "metadata": {},
-      "source": [
-        "Using db_connection, we can run our queries much like the `%%sql` command."
-      ]
+      "source": "Using db_connection, we can run our queries much like in a SQL cell."
     },
     {
       "cell_type": "code",
@@ -205,87 +133,52 @@
       "id": "cb22f3b0-547a-471b-80d3-213b38f41121",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "query1 = 'SELECT * FROM users LIMIT 3;'\n",
-        "\n",
-        "for row in db_connection2.execute(query1):\n",
-        "    print(row)"
-      ]
+      "source": "query1 = 'SELECT * FROM users LIMIT 3;'\n\nfor row in db_connection2.execute(query1):\n    print(row)"
     },
     {
       "cell_type": "markdown",
       "id": "1a15dcbc-4a03-49c2-ae18-130d97fb03e9",
       "metadata": {},
-      "source": [
-        "# 2. Connecting to an external datasource\n",
-        "\n",
-        "You can securely connect to external endpoints from your SingleStoreDB notebooks. By default, connections are limited to SingleStoreDB databases; however, you can enable and disable connections to other external endpoints via the allowlist. To add or remove endpoints from the allowlist:\n",
-        "\n",
-        "1. Select Edit Firewall at the top-left of this notebook.\n",
-        "\n",
-        "<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/notebook-basics/images/edit-firewall.png\" style=\"width: 200px; border: 1px solid darkorchid\">\n",
-        "\n",
-        "2. Select Edit to add new endpoints:\n",
-        "\n",
-        "<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/notebook-basics/images/new-endpoints.png\" style=\"width: 350px; border: 1px solid darkorchid\">\n",
-        "\n",
-        "3. In the Edit Allowlist dialog, you can add a Fully Qualified Domain Name (FQDN) or select from a list of suggested FQDNs (for example `pypi.org` or `github.com`). You can provide wildcard access to an endpoint by using the `*` character. For example, to access an AWS S3 endpoints, you can use the following syntax:  `*.s3.*.amazonaws.com`\n",
-        "4. Select Save.\n",
-        "\n",
-        "<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/notebook-basics/images/connect-to-an-external-datasource.png\" style=\"width: 500px; border: 1px solid darkorchid\">"
-      ]
+      "source": "# 2. Connecting to an external datasource\n\nYou can securely connect to external endpoints from your SingleStoreDB notebooks. By default, connections are limited to SingleStoreDB databases; however, you can enable and disable connections to other external endpoints via the allowlist. To add or remove endpoints from the allowlist:\n\n1. Select Edit Firewall at the top-left of this notebook.\n\n<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/notebook-basics/images/edit-firewall.png\" style=\"width: 200px; border: 1px solid darkorchid\">\n\n2. Select Edit to add new endpoints:\n\n<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/notebook-basics/images/new-endpoints.png\" style=\"width: 350px; border: 1px solid darkorchid\">\n\n3. In the Edit Allowlist dialog, you can add a Fully Qualified Domain Name (FQDN) or select from a list of suggested FQDNs (for example `pypi.org` or `github.com`). You can provide wildcard access to an endpoint by using the `*` character. For example, to access an AWS S3 endpoints, you can use the following syntax:  `*.s3.*.amazonaws.com`\n4. Select Save.\n\n<img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/notebook-basics/images/connect-to-an-external-datasource.png\" style=\"width: 500px; border: 1px solid darkorchid\">"
     },
     {
       "cell_type": "markdown",
       "id": "3eed3310-621f-4c37-9db4-a992980a4f46",
       "metadata": {},
-      "source": [
-        "# 3. Using SQL\n",
-        "The default language for SingleStoreDB Cloud notebooks is Python. However, the `%%sql` magic command can be used to\n",
-        "submit SQL code for an entire cell."
-      ]
+      "source": "# 3. Using SQL\nThe default language for SingleStoreDB Cloud notebooks is Python. However, by selecting SQL in the cell type dropdown, SQL code can be submitted for an entire cell."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "d82fc6bf-b786-4956-a056-851e746f97b8",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "SELECT * FROM users\n",
-        "    LIMIT 3;"
-      ]
+      "source": "SELECT * FROM users\n    LIMIT 3;"
     },
     {
       "cell_type": "markdown",
       "id": "eb91c21c-1ce6-4e31-95d1-a981dea630c7",
       "metadata": {},
-      "source": [
-        "By default, the results are displayed as a table. We can also store the result in a variable for use later in the\n",
-        "notebook. The following code includes the `result1 <<` syntax which indicates that the output of the SQL code\n",
-        "should be stored in the `result` variable in the Python environment."
-      ]
+      "source": "By default, the results are displayed as a table. We can also store the result in a variable for use later in the\nnotebook. The following cell specifies the output variable `result1` which indicates that the output of the SQL code\nshould be stored in the `result1` variable in the Python environment."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "0a6341cd-0328-4d8a-8158-72aff97b77de",
-      "metadata": {},
+      "metadata": {
+        "language": "sql",
+        "output_variable": "result1"
+      },
       "outputs": [],
-      "source": [
-        "%%sql result1 <<\n",
-        "SELECT * FROM users\n",
-        "    LIMIT 3;"
-      ]
+      "source": "SELECT * FROM users\n    LIMIT 3;"
     },
     {
       "cell_type": "markdown",
       "id": "91cf2054-d223-4013-8867-2f4a9494978a",
       "metadata": {},
-      "source": [
-        "We now have access to the `result` variable and can convert it to a DataFrame!"
-      ]
+      "source": "We now have access to the `result1` variable and can convert it to a DataFrame!"
     },
     {
       "cell_type": "code",
@@ -293,24 +186,13 @@
       "id": "5e436bc0-4843-4d0c-b64c-3470d963f29a",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import pandas as pd\n",
-        "\n",
-        "df = pd.DataFrame(result1)\n",
-        "df"
-      ]
+      "source": "import pandas as pd\n\ndf = pd.DataFrame(result1)\ndf"
     },
     {
       "cell_type": "markdown",
       "id": "360b2dc0-038e-4311-a5c3-b497b8feaf57",
       "metadata": {},
-      "source": [
-        "## 4. Using Python in a code cell\n",
-        "\n",
-        "By default, Python is the language for code cells. In the cell below, we are using a SQLAlchemy connection to execute\n",
-        "the same query as the previous example. The result of this query can be converted into a DataFrame in the same manner\n",
-        "as above"
-      ]
+      "source": "## 4. Using Python in a code cell\n\nBy default, Python is the language for code cells. In the cell below, we are using a SQLAlchemy connection to execute\nthe same query as the previous example. The result of this query can be converted into a DataFrame in the same manner\nas above"
     },
     {
       "cell_type": "code",
@@ -318,24 +200,13 @@
       "id": "e0085cca-2278-4904-94aa-4e46da840b66",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "result = db_connection.execute('SELECT * FROM users LIMIT 3;')\n",
-        "\n",
-        "df = pd.DataFrame(result)\n",
-        "df"
-      ]
+      "source": "result = db_connection.execute('SELECT * FROM users LIMIT 3;')\n\ndf = pd.DataFrame(result)\ndf"
     },
     {
       "cell_type": "markdown",
       "id": "afb80434-583d-4171-a95b-694ed14bbd98",
       "metadata": {},
-      "source": [
-        "## 5. Using both SQL & Python in a code cell\n",
-        "\n",
-        "We can use a single line of SQL within a Python cell using a single `%sql` call. Below we combine SQL and \n",
-        "Python in the same cell to capture the output in the `result` variable. We then convert it to a DataFrame \n",
-        "as in previous examples."
-      ]
+      "source": "## 5. Using both SQL & Python in a code cell\n\nWe can use a single line of SQL within a Python cell using a single `%sql` call. Below we combine SQL and \nPython in the same cell to capture the output in the `result` variable. We then convert it to a DataFrame \nas in previous examples."
     },
     {
       "cell_type": "code",
@@ -343,22 +214,13 @@
       "id": "d79f9268-7c76-47cf-bee7-577ce07ae85d",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "result = %sql SELECT * FROM users LIMIT 3;\n",
-        "\n",
-        "df = pd.DataFrame(result)\n",
-        "df"
-      ]
+      "source": "result = %sql SELECT * FROM users LIMIT 3;\n\ndf = pd.DataFrame(result)\ndf"
     },
     {
       "cell_type": "markdown",
       "id": "2b9a3995-32df-4931-8aff-44bcd2db5908",
       "metadata": {},
-      "source": [
-        "## 6. Preinstalled libraries\n",
-        "\n",
-        "By default, a SingleStoreDB notebook has a large number of preinstalled libraries. Run the cell below to see what libraries are already installed!"
-      ]
+      "source": "## 6. Preinstalled libraries\n\nBy default, a SingleStoreDB notebook has a large number of preinstalled libraries. Run the cell below to see what libraries are already installed!"
     },
     {
       "cell_type": "code",
@@ -366,17 +228,13 @@
       "id": "abee048d-f18a-4a35-8eae-c8f92939230a",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip list"
-      ]
+      "source": "!pip list"
     },
     {
       "cell_type": "markdown",
       "id": "bbc061e3-acb3-40cc-be84-ada979aaa1a5",
       "metadata": {},
-      "source": [
-        "Our notebooks support libraries available from https://pypi.org/. For example, run the cell below to install the [Kaggle open dataset library](https://pypi.org/project/opendatasets/) to install the `opendatasets` package."
-      ]
+      "source": "Our notebooks support libraries available from https://pypi.org/. For example, run the cell below to install the [Kaggle open dataset library](https://pypi.org/project/opendatasets/) to install the `opendatasets` package."
     },
     {
       "cell_type": "code",
@@ -384,17 +242,13 @@
       "id": "e17e1322-33df-4e2f-97fe-9815df235b40",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip3 install opendatasets"
-      ]
+      "source": "!pip3 install opendatasets"
     },
     {
       "cell_type": "markdown",
       "id": "9c6684da-af62-42bc-9481-b53c75f64b5e",
       "metadata": {},
-      "source": [
-        "You can even upgrade versions of a preinstalled library. Run the cell below to get the new version of Plotly."
-      ]
+      "source": "You can even upgrade versions of a preinstalled library. Run the cell below to get the new version of Plotly."
     },
     {
       "cell_type": "code",
@@ -402,23 +256,13 @@
       "id": "5a989a0f-6334-42d9-a75e-a04d09bccbec",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip3 install plotly --upgrade"
-      ]
+      "source": "!pip3 install plotly --upgrade"
     },
     {
       "cell_type": "markdown",
       "id": "8d69cb4d-58ea-40ae-83db-03ff489d8676",
       "metadata": {},
-      "source": [
-        "## 7. Magic commands\n",
-        "\n",
-        "Magic commands in Jupyter Notebook are special commands that allow you to perform various tasks that are not part of the standard Python language. We have demonstrated two of the included magic commands already: `%%sql` for submitting entire cells of\n",
-        "SQL code and `%sql` for submitting a single query in the context of a Python code cell.\n",
-        "\n",
-        "There are many other magic commands as well for everything from file system access to debugging your Python code.\n",
-        "For information about teh full list of magic commands available, run the code cell below."
-      ]
+      "source": "## 7. Magic commands\n\nMagic commands in Jupyter Notebook are special commands that allow you to perform various tasks that are not part of the standard Python language. We have demonstrated one of the included magic commands already: `%sql` for submitting a single query in the context of a Python code cell.\n\nThere are many other magic commands as well for everything from file system access to debugging your Python code.\nFor information about teh full list of magic commands available, run the code cell below."
     },
     {
       "cell_type": "code",
@@ -426,26 +270,19 @@
       "id": "b413bb30-0e9f-4484-8d3e-e7bc724a0c13",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%quickref"
-      ]
+      "source": "%quickref"
     },
     {
       "cell_type": "markdown",
       "id": "0ea02e78-b1e2-4cb4-a6d7-d813fdcb2759",
       "metadata": {},
-      "source": [
-        "**Learn more about SingleStoreDB notebooks [here](https://docs.singlestore.com/managed-service/en/developer-resources/notebooks.html) and get started with your first notebook!**"
-      ]
+      "source": "**Learn more about SingleStoreDB notebooks [here](https://docs.singlestore.com/managed-service/en/developer-resources/notebooks.html) and get started with your first notebook!**"
     },
     {
       "cell_type": "markdown",
       "id": "df3c9ee9-ac57-4e84-9201-df635ac7bd36",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -464,7 +301,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/semantic-search-with-hugging-face/notebook.ipynb
+++ b/notebooks/semantic-search-with-hugging-face/notebook.ipynb
@@ -4,23 +4,13 @@
       "cell_type": "markdown",
       "id": "8e19358e-22e8-406c-ae17-d916db889313",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(210, 255, 153, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/chart-network.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Semantic Search with Hugging Face Models and Datasets</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(210, 255, 153, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/chart-network.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Semantic Search with Hugging Face Models and Datasets</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "9bebf253-7913-4d7a-8ebc-f10463803baa",
       "metadata": {},
-      "source": "In this notebook, we will demonstrate an example of conducting semantic search on SingleStoreDB with SQL! Unlike traditional keyword-based search methods, semantic search algorithms take into account the relationships between words and their meanings, enabling them to deliver more accurate and relevant results \u2013 even when search terms are vague or ambiguous. \n\nSingleStoreDB\u2019s built-in parallelization and Intel SIMD-based vector processing takes care of the heavy lifting involved in processing vector data. This allows your to run your ML algorithms right in your database extremely efficiently with just 1 line of SQL!\n\nIn this example, we use Hugging Face to create embeddings for our dataset and run semantic_search using dot_product vector matching function!"
+      "source": "In this notebook, we will demonstrate an example of conducting semantic search on SingleStoreDB with SQL! Unlike traditional keyword-based search methods, semantic search algorithms take into account the relationships between words and their meanings, enabling them to deliver more accurate and relevant results – even when search terms are vague or ambiguous. \n\nSingleStoreDB’s built-in parallelization and Intel SIMD-based vector processing takes care of the heavy lifting involved in processing vector data. This allows your to run your ML algorithms right in your database extremely efficiently with just 1 line of SQL!\n\nIn this example, we use Hugging Face to create embeddings for our dataset and run semantic_search using dot_product vector matching function!"
     },
     {
       "cell_type": "markdown",
@@ -32,15 +22,17 @@
       "cell_type": "code",
       "execution_count": null,
       "id": "af5e02fb-e15b-4c85-ac69-a40dd974cd88",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": "%%sql\nDROP DATABASE IF EXISTS semantic_search;\n\nCREATE DATABASE semantic_search;"
+      "source": "DROP DATABASE IF EXISTS semantic_search;\n\nCREATE DATABASE semantic_search;"
     },
     {
       "cell_type": "markdown",
       "id": "284f2bdc-a428-4a55-9f1f-fce623914b34",
       "metadata": {},
-      "source": "<div class=\"alert alert-block alert-warning\">\n    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n    <div>\n        <p><b>Action Required</b></p>\n        <p>Make sure to select the <tt>semantic_search</tt> database from the drop-down menu at the top of this notebook.\n        It updates the <tt>connection_url</tt> which is used by the <tt>%%sql</tt> magic command and SQLAlchemy to make connections to the selected database.</p>\n    </div>\n</div>"
+      "source": "<div class=\"alert alert-block alert-warning\">\n    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n    <div>\n        <p><b>Action Required</b></p>\n        <p>Make sure to select the <tt>semantic_search</tt> database from the drop-down menu at the top of this notebook.\n        It updates the <tt>connection_url</tt> which is used by SQLAlchemy to make connections to the selected database.</p>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
@@ -116,7 +108,7 @@
       "cell_type": "markdown",
       "id": "8188ccb2-d5cf-48b5-8c9f-8b3858c18ae7",
       "metadata": {},
-      "source": "## 7. Insert data into SingleStoreDB\n\nYou can seamlessly bring this data to your SingleStoreDB table directly from your from `DataFrame`. SingleStore \u2665\ufe0f Python.\n\nWe will bring this data into a table called `reviews`. Notice how you don't have to write any SQL for this\u00a0\u2013\u00a0we will infer the schema from your `DataFrame` and underneath the hood configure how to bring this `DataFrame` into our database. Since numpy arrays don't map directly to a database type, we give pandas a type hint to create a blob column for the `review_embeddings` column. "
+      "source": "## 7. Insert data into SingleStoreDB\n\nYou can seamlessly bring this data to your SingleStoreDB table directly from your from `DataFrame`. SingleStore ♥️ Python.\n\nWe will bring this data into a table called `reviews`. Notice how you don't have to write any SQL for this – we will infer the schema from your `DataFrame` and underneath the hood configure how to bring this `DataFrame` into our database. Since numpy arrays don't map directly to a database type, we give pandas a type hint to create a blob column for the `review_embeddings` column. "
     },
     {
       "cell_type": "code",
@@ -138,7 +130,7 @@
       "cell_type": "markdown",
       "id": "e34e62fb-7690-4a31-a874-ff7856d16cc7",
       "metadata": {},
-      "source": "## 8. Run the semantic search algorithm with just one line of SQL\n\nWe will utilize SingleStoreDB's distributed architecture to efficiently compute the dot product of the input string (stored in searchstring) with each entry in the database and return the top 5  reviews with the highest dot product score. Each vector is normalized to length 1, hence the dot product function essentially computes the cosine similarity between two vectors \u2013 an appropriate nearness metric. SingleStoreDB makes this extremely fast because it compiles queries to machine code and runs dot_product using SIMD instructions."
+      "source": "## 8. Run the semantic search algorithm with just one line of SQL\n\nWe will utilize SingleStoreDB's distributed architecture to efficiently compute the dot product of the input string (stored in searchstring) with each entry in the database and return the top 5  reviews with the highest dot product score. Each vector is normalized to length 1, hence the dot product function essentially computes the cosine similarity between two vectors – an appropriate nearness metric. SingleStoreDB makes this extremely fast because it compiles queries to machine code and runs dot_product using SIMD instructions."
     },
     {
       "cell_type": "code",
@@ -158,18 +150,17 @@
       "cell_type": "code",
       "execution_count": null,
       "id": "0e91592f-4856-4cab-b15e-23585f551ab3",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": "%%sql\nDROP DATABASE semantic_search;"
+      "source": "DROP DATABASE semantic_search;"
     },
     {
       "cell_type": "markdown",
       "id": "a6829f66-b37e-493d-9631-6da519140485",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -188,7 +179,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.10.9"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/semantic-search-with-hugging-face/notebook.ipynb
+++ b/notebooks/semantic-search-with-hugging-face/notebook.ipynb
@@ -10,7 +10,7 @@
       "cell_type": "markdown",
       "id": "9bebf253-7913-4d7a-8ebc-f10463803baa",
       "metadata": {},
-      "source": "In this notebook, we will demonstrate an example of conducting semantic search on SingleStoreDB with SQL! Unlike traditional keyword-based search methods, semantic search algorithms take into account the relationships between words and their meanings, enabling them to deliver more accurate and relevant results – even when search terms are vague or ambiguous. \n\nSingleStoreDB’s built-in parallelization and Intel SIMD-based vector processing takes care of the heavy lifting involved in processing vector data. This allows your to run your ML algorithms right in your database extremely efficiently with just 1 line of SQL!\n\nIn this example, we use Hugging Face to create embeddings for our dataset and run semantic_search using dot_product vector matching function!"
+      "source": "In this notebook, we will demonstrate an example of conducting semantic search on SingleStoreDB with SQL! Unlike traditional keyword-based search methods, semantic search algorithms take into account the relationships between words and their meanings, enabling them to deliver more accurate and relevant results \u2013 even when search terms are vague or ambiguous. \n\nSingleStoreDB\u2019s built-in parallelization and Intel SIMD-based vector processing takes care of the heavy lifting involved in processing vector data. This allows your to run your ML algorithms right in your database extremely efficiently with just 1 line of SQL!\n\nIn this example, we use Hugging Face to create embeddings for our dataset and run semantic_search using dot_product vector matching function!"
     },
     {
       "cell_type": "markdown",
@@ -108,7 +108,7 @@
       "cell_type": "markdown",
       "id": "8188ccb2-d5cf-48b5-8c9f-8b3858c18ae7",
       "metadata": {},
-      "source": "## 7. Insert data into SingleStoreDB\n\nYou can seamlessly bring this data to your SingleStoreDB table directly from your from `DataFrame`. SingleStore ♥️ Python.\n\nWe will bring this data into a table called `reviews`. Notice how you don't have to write any SQL for this – we will infer the schema from your `DataFrame` and underneath the hood configure how to bring this `DataFrame` into our database. Since numpy arrays don't map directly to a database type, we give pandas a type hint to create a blob column for the `review_embeddings` column. "
+      "source": "## 7. Insert data into SingleStoreDB\n\nYou can seamlessly bring this data to your SingleStoreDB table directly from your from `DataFrame`. SingleStore \u2665\ufe0f Python.\n\nWe will bring this data into a table called `reviews`. Notice how you don't have to write any SQL for this\u00a0\u2013\u00a0we will infer the schema from your `DataFrame` and underneath the hood configure how to bring this `DataFrame` into our database. Since numpy arrays don't map directly to a database type, we give pandas a type hint to create a blob column for the `review_embeddings` column. "
     },
     {
       "cell_type": "code",
@@ -130,7 +130,7 @@
       "cell_type": "markdown",
       "id": "e34e62fb-7690-4a31-a874-ff7856d16cc7",
       "metadata": {},
-      "source": "## 8. Run the semantic search algorithm with just one line of SQL\n\nWe will utilize SingleStoreDB's distributed architecture to efficiently compute the dot product of the input string (stored in searchstring) with each entry in the database and return the top 5  reviews with the highest dot product score. Each vector is normalized to length 1, hence the dot product function essentially computes the cosine similarity between two vectors – an appropriate nearness metric. SingleStoreDB makes this extremely fast because it compiles queries to machine code and runs dot_product using SIMD instructions."
+      "source": "## 8. Run the semantic search algorithm with just one line of SQL\n\nWe will utilize SingleStoreDB's distributed architecture to efficiently compute the dot product of the input string (stored in searchstring) with each entry in the database and return the top 5  reviews with the highest dot product score. Each vector is normalized to length 1, hence the dot product function essentially computes the cosine similarity between two vectors \u2013 an appropriate nearness metric. SingleStoreDB makes this extremely fast because it compiles queries to machine code and runs dot_product using SIMD instructions."
     },
     {
       "cell_type": "code",

--- a/notebooks/semantic-search-with-openai-embedding-creation/notebook.ipynb
+++ b/notebooks/semantic-search-with-openai-embedding-creation/notebook.ipynb
@@ -10,7 +10,7 @@
       "cell_type": "markdown",
       "id": "9bebf253-7913-4d7a-8ebc-f10463803baa",
       "metadata": {},
-      "source": "In this notebook, we will demonstrate an example of conducting semantic search on SingleStoreDB with SQL! Unlike traditional keyword-based search methods, semantic search algorithms take into account the relationships between words and their meanings, enabling them to deliver more accurate and relevant results – even when search terms are vague or ambiguous. \n\nSingleStoreDB’s built-in parallelization and Intel SIMD-based vector processing takes care of the heavy lifting involved in processing vector data. This allows your to run your ML algorithms right in your database extremely efficiently with just 2 lines of SQL!\n\n\nIn this example, we use Open AI embeddings API to create embeddings for our dataset and run semantic_search using dot_product vector matching function!"
+      "source": "In this notebook, we will demonstrate an example of conducting semantic search on SingleStoreDB with SQL! Unlike traditional keyword-based search methods, semantic search algorithms take into account the relationships between words and their meanings, enabling them to deliver more accurate and relevant results \u2013 even when search terms are vague or ambiguous. \n\nSingleStoreDB\u2019s built-in parallelization and Intel SIMD-based vector processing takes care of the heavy lifting involved in processing vector data. This allows your to run your ML algorithms right in your database extremely efficiently with just 2 lines of SQL!\n\n\nIn this example, we use Open AI embeddings API to create embeddings for our dataset and run semantic_search using dot_product vector matching function!"
     },
     {
       "cell_type": "markdown",
@@ -116,7 +116,7 @@
       "cell_type": "markdown",
       "id": "8188ccb2-d5cf-48b5-8c9f-8b3858c18ae7",
       "metadata": {},
-      "source": "## 7. Add vector embeddings for each review\n\nTo embed the reviews in our SingleStoreDB database, we iterate through each row in the table, make a call to OpenAI’s embeddings API with the text in the reviews field and update the new column called embeddings for each entry. "
+      "source": "## 7. Add vector embeddings for each review\n\nTo embed the reviews in our SingleStoreDB database, we iterate through each row in the table, make a call to OpenAI\u2019s embeddings API with the text in the reviews field and update the new column called embeddings for each entry. "
     },
     {
       "cell_type": "code",
@@ -130,7 +130,7 @@
       "cell_type": "markdown",
       "id": "e34e62fb-7690-4a31-a874-ff7856d16cc7",
       "metadata": {},
-      "source": "## 8. Run the semantic search algorithm with just one line of SQL\n\nWe will utilize SingleStoreDB's distributed architecture to efficiently compute the dot product of the input string (stored in searchstring) with each entry in the database and return the top 5  reviews with the highest dot product score. Each vector is normalized to length 1, hence the dot product function essentially computes the cosine similarity between two vectors – an appropriate nearness metric. SingleStoreDB makes this extremely fast because it compiles queries to machine code and runs dot_product using SIMD instructions."
+      "source": "## 8. Run the semantic search algorithm with just one line of SQL\n\nWe will utilize SingleStoreDB's distributed architecture to efficiently compute the dot product of the input string (stored in searchstring) with each entry in the database and return the top 5  reviews with the highest dot product score. Each vector is normalized to length 1, hence the dot product function essentially computes the cosine similarity between two vectors \u2013 an appropriate nearness metric. SingleStoreDB makes this extremely fast because it compiles queries to machine code and runs dot_product using SIMD instructions."
     },
     {
       "cell_type": "code",

--- a/notebooks/semantic-search-with-openai-embedding-creation/notebook.ipynb
+++ b/notebooks/semantic-search-with-openai-embedding-creation/notebook.ipynb
@@ -4,80 +4,41 @@
       "cell_type": "markdown",
       "id": "8e19358e-22e8-406c-ae17-d916db889313",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(210, 255, 153, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/chart-network.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Semantic Search with OpenAI Embedding Creation</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(210, 255, 153, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/chart-network.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Semantic Search with OpenAI Embedding Creation</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "9bebf253-7913-4d7a-8ebc-f10463803baa",
       "metadata": {},
-      "source": [
-        "In this notebook, we will demonstrate an example of conducting semantic search on SingleStoreDB with SQL! Unlike traditional keyword-based search methods, semantic search algorithms take into account the relationships between words and their meanings, enabling them to deliver more accurate and relevant results \u2013 even when search terms are vague or ambiguous. \n",
-        "\n",
-        "SingleStoreDB\u2019s built-in parallelization and Intel SIMD-based vector processing takes care of the heavy lifting involved in processing vector data. This allows your to run your ML algorithms right in your database extremely efficiently with just 2 lines of SQL!\n",
-        "\n",
-        "\n",
-        "In this example, we use Open AI embeddings API to create embeddings for our dataset and run semantic_search using dot_product vector matching function!"
-      ]
+      "source": "In this notebook, we will demonstrate an example of conducting semantic search on SingleStoreDB with SQL! Unlike traditional keyword-based search methods, semantic search algorithms take into account the relationships between words and their meanings, enabling them to deliver more accurate and relevant results – even when search terms are vague or ambiguous. \n\nSingleStoreDB’s built-in parallelization and Intel SIMD-based vector processing takes care of the heavy lifting involved in processing vector data. This allows your to run your ML algorithms right in your database extremely efficiently with just 2 lines of SQL!\n\n\nIn this example, we use Open AI embeddings API to create embeddings for our dataset and run semantic_search using dot_product vector matching function!"
     },
     {
       "cell_type": "markdown",
       "id": "358d1eb0-a0dd-423d-86ea-0d131abe4169",
       "metadata": {},
-      "source": [
-        "## 1. Create a workspace in your workspace group\n",
-        "\n",
-        "S-00 is sufficient.\n",
-        "\n",
-        "## 2. Create a Database named `semantic_search`"
-      ]
+      "source": "## 1. Create a workspace in your workspace group\n\nS-00 is sufficient.\n\n## 2. Create a Database named `semantic_search`"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "af5e02fb-e15b-4c85-ac69-a40dd974cd88",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE IF EXISTS semantic_search;\n",
-        "\n",
-        "CREATE DATABASE semantic_search;"
-      ]
+      "source": "DROP DATABASE IF EXISTS semantic_search;\n\nCREATE DATABASE semantic_search;"
     },
     {
       "cell_type": "markdown",
       "id": "284f2bdc-a428-4a55-9f1f-fce623914b34",
       "metadata": {},
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n",
-        "    <div>\n",
-        "        <p><b>Action Required</b></p>\n",
-        "        <p>Make sure to select the <tt>semantic_search</tt> database from the drop-down menu at the top of this notebook.\n",
-        "        It updates the <tt>connection_url</tt> which is used by the <tt>%%sql</tt> magic command and SQLAlchemy to make connections to the selected database.</p>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div class=\"alert alert-block alert-warning\">\n    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n    <div>\n        <p><b>Action Required</b></p>\n        <p>Make sure to select the <tt>semantic_search</tt> database from the drop-down menu at the top of this notebook.\n        It updates the <tt>connection_url</tt> which is used by SQLAlchemy to make connections to the selected database.</p>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "8124ab1c-7f17-47bc-9f8a-c7bd5a33a426",
       "metadata": {},
-      "source": [
-        "## 3. Install and import required libraries\n",
-        "\n",
-        "We will use the OpenAI embeddings API and will need to import the relevant dependencies accordingly. "
-      ]
+      "source": "## 3. Install and import required libraries\n\nWe will use the OpenAI embeddings API and will need to import the relevant dependencies accordingly. "
     },
     {
       "cell_type": "code",
@@ -85,40 +46,19 @@
       "id": "af6146b2-a044-4dd8-b020-e3d8c1f91aba",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip3 install openai matplotlib plotly pandas scipy scikit-learn requests --quiet\n",
-        "\n",
-        "import json\n",
-        "import os\n",
-        "\n",
-        "import openai\n",
-        "import requests\n",
-        "from openai.embeddings_utils import get_embedding"
-      ]
+      "source": "!pip3 install openai matplotlib plotly pandas scipy scikit-learn requests --quiet\n\nimport json\nimport os\n\nimport openai\nimport requests\nfrom openai.embeddings_utils import get_embedding"
     },
     {
       "cell_type": "markdown",
       "id": "f80d23bc-7e98-4ac8-b2a0-7a737e4010e5",
       "metadata": {},
-      "source": [
-        "## 4. Create an OpenAI account and get API connection details\n",
-        "\n",
-        "To vectorize and embed the employee reviews and query strings, we leverage OpenAI's embeddings API. To use this API, you will need an API key, which you can get [here](https://platform.openai.com/account/api-keys). You'll need to add a payment method to actually get vector embeddings using the API, though the charges are minimal for a small example like we present here."
-      ]
+      "source": "## 4. Create an OpenAI account and get API connection details\n\nTo vectorize and embed the employee reviews and query strings, we leverage OpenAI's embeddings API. To use this API, you will need an API key, which you can get [here](https://platform.openai.com/account/api-keys). You'll need to add a payment method to actually get vector embeddings using the API, though the charges are minimal for a small example like we present here."
     },
     {
       "cell_type": "markdown",
       "id": "22de8d4c-6b79-4496-8812-37e0b82e980b",
       "metadata": {},
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n",
-        "    <div>\n",
-        "        <p><b>Action Required</b></p>\n",
-        "        <p>You will have to update your notebook's firewall settings to include <tt>*.*.openai.com</tt> in order to get embedddings from OpenAI APIS.</p>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div class=\"alert alert-block alert-warning\">\n    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n    <div>\n        <p><b>Action Required</b></p>\n        <p>You will have to update your notebook's firewall settings to include <tt>*.*.openai.com</tt> in order to get embedddings from OpenAI APIS.</p>\n    </div>\n</div>"
     },
     {
       "cell_type": "code",
@@ -126,43 +66,29 @@
       "id": "a463c0fd-c747-4605-a728-c22a2fa17cfb",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "openai.api_key = '<OPEN_AI_API_KEY>'"
-      ]
+      "source": "openai.api_key = '<OPEN_AI_API_KEY>'"
     },
     {
       "cell_type": "markdown",
       "id": "17fb3aad-e3a8-4a2a-985c-64f0c94431b8",
       "metadata": {},
-      "source": [
-        "## 5. Create a new table in your database called reviews"
-      ]
+      "source": "## 5. Create a new table in your database called reviews"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "e3af3810-0ce5-432b-a879-4eaa16524d38",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "CREATE TABLE reviews (\n",
-        "    date_review VARCHAR(255), \n",
-        "    job_title VARCHAR(255), \n",
-        "    location VARCHAR(255), \n",
-        "    review TEXT\n",
-        ");"
-      ]
+      "source": "CREATE TABLE reviews (\n    date_review VARCHAR(255), \n    job_title VARCHAR(255), \n    location VARCHAR(255), \n    review TEXT\n);"
     },
     {
       "cell_type": "markdown",
       "id": "db124797-a11c-4a97-9f58-b337c50014e3",
       "metadata": {},
-      "source": [
-        "## 6. Import our sample data into your table\n",
-        "\n",
-        "This dataset has 15 reviews left by anonymous employees of a firm."
-      ]
+      "source": "## 6. Import our sample data into your table\n\nThis dataset has 15 reviews left by anonymous employees of a firm."
     },
     {
       "cell_type": "code",
@@ -170,19 +96,13 @@
       "id": "bce5a7cb-ad4f-4293-8bc3-9d09f76ae5e8",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "url = 'https://raw.githubusercontent.com/singlestore-labs/singlestoredb-samples/main/' + \\\n",
-        "      'Tutorials/ai-powered-semantic-search/hr_sample_data.sql'"
-      ]
+      "source": "url = 'https://raw.githubusercontent.com/singlestore-labs/singlestoredb-samples/main/' + \\\n      'Tutorials/ai-powered-semantic-search/hr_sample_data.sql'"
     },
     {
       "cell_type": "markdown",
       "id": "7ddec245-7c79-40ea-85b2-7a88e25e5321",
       "metadata": {},
-      "source": [
-        "Note that we are using the `%sql` magic command here to run a query against the currently\n",
-        "selected database."
-      ]
+      "source": "Note that we are using the `%sql` magic command here to run a query against the currently\nselected database."
     },
     {
       "cell_type": "code",
@@ -190,20 +110,13 @@
       "id": "227c2fcf-2dc8-4ed2-92f1-5a28667bf3d3",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "for query in [x for x in requests.get(url).text.split('\\n') if x.strip()]:\n",
-        "     %sql {{query}}"
-      ]
+      "source": "for query in [x for x in requests.get(url).text.split('\\n') if x.strip()]:\n     %sql {{query}}"
     },
     {
       "cell_type": "markdown",
       "id": "8188ccb2-d5cf-48b5-8c9f-8b3858c18ae7",
       "metadata": {},
-      "source": [
-        "## 7. Add vector embeddings for each review\n",
-        "\n",
-        "To embed the reviews in our SingleStoreDB database, we iterate through each row in the table, make a call to OpenAI\u2019s embeddings API with the text in the reviews field and update the new column called embeddings for each entry. "
-      ]
+      "source": "## 7. Add vector embeddings for each review\n\nTo embed the reviews in our SingleStoreDB database, we iterate through each row in the table, make a call to OpenAI’s embeddings API with the text in the reviews field and update the new column called embeddings for each entry. "
     },
     {
       "cell_type": "code",
@@ -211,25 +124,13 @@
       "id": "419a690a-810c-4c80-b7ea-fd25cf1d5e80",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "%sql ALTER TABLE reviews ADD embeddings BLOB;\n",
-        "\n",
-        "reviews = %sql SELECT review FROM reviews;\n",
-        "\n",
-        "for i in reviews:\n",
-        "    review_embedding = json.dumps(get_embedding(i[0], engine=\"text-embedding-ada-002\"))\n",
-        "    %sql UPDATE reviews SET embeddings = JSON_ARRAY_PACK('{{review_embedding}}') WHERE review='{{i[0]}}';"
-      ]
+      "source": "%sql ALTER TABLE reviews ADD embeddings BLOB;\n\nreviews = %sql SELECT review FROM reviews;\n\nfor i in reviews:\n    review_embedding = json.dumps(get_embedding(i[0], engine=\"text-embedding-ada-002\"))\n    %sql UPDATE reviews SET embeddings = JSON_ARRAY_PACK('{{review_embedding}}') WHERE review='{{i[0]}}';"
     },
     {
       "cell_type": "markdown",
       "id": "e34e62fb-7690-4a31-a874-ff7856d16cc7",
       "metadata": {},
-      "source": [
-        "## 8. Run the semantic search algorithm with just one line of SQL\n",
-        "\n",
-        "We will utilize SingleStoreDB's distributed architecture to efficiently compute the dot product of the input string (stored in searchstring) with each entry in the database and return the top 5  reviews with the highest dot product score. Each vector is normalized to length 1, hence the dot product function essentially computes the cosine similarity between two vectors \u2013 an appropriate nearness metric. SingleStoreDB makes this extremely fast because it compiles queries to machine code and runs dot_product using SIMD instructions."
-      ]
+      "source": "## 8. Run the semantic search algorithm with just one line of SQL\n\nWe will utilize SingleStoreDB's distributed architecture to efficiently compute the dot product of the input string (stored in searchstring) with each entry in the database and return the top 5  reviews with the highest dot product score. Each vector is normalized to length 1, hence the dot product function essentially computes the cosine similarity between two vectors – an appropriate nearness metric. SingleStoreDB makes this extremely fast because it compiles queries to machine code and runs dot_product using SIMD instructions."
     },
     {
       "cell_type": "code",
@@ -237,44 +138,29 @@
       "id": "08bd6b1c-9731-4062-9b9a-a5e1a1d8efa3",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "searchstring = input(\"Please enter a search string: \")\n",
-        "\n",
-        "search_embedding = json.dumps(get_embedding(searchstring, engine=\"text-embedding-ada-002\")) \n",
-        "\n",
-        "results = %sql SELECT review, DOT_PRODUCT(embeddings, JSON_ARRAY_PACK('{{search_embedding}}')) AS Score FROM reviews ORDER BY Score DESC LIMIT 5;\n",
-        "\n",
-        "for i, res in enumerate(results):\n",
-        "    print(f'{i + 1}: {res[0]} Score: {res[1]}')"
-      ]
+      "source": "searchstring = input(\"Please enter a search string: \")\n\nsearch_embedding = json.dumps(get_embedding(searchstring, engine=\"text-embedding-ada-002\")) \n\nresults = %sql SELECT review, DOT_PRODUCT(embeddings, JSON_ARRAY_PACK('{{search_embedding}}')) AS Score FROM reviews ORDER BY Score DESC LIMIT 5;\n\nfor i, res in enumerate(results):\n    print(f'{i + 1}: {res[0]} Score: {res[1]}')"
     },
     {
       "cell_type": "markdown",
       "id": "0383939d-7fd3-434d-a27b-952eeed40e5f",
       "metadata": {},
-      "source": [
-        "## 9. Clean up"
-      ]
+      "source": "## 9. Clean up"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "0e91592f-4856-4cab-b15e-23585f551ab3",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE semantic_search;"
-      ]
+      "source": "DROP DATABASE semantic_search;"
     },
     {
       "cell_type": "markdown",
       "id": "a6829f66-b37e-493d-9631-6da519140485",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -293,7 +179,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/notebooks/semantic-search-with-openai-qa/notebook.ipynb
+++ b/notebooks/semantic-search-with-openai-qa/notebook.ipynb
@@ -4,35 +4,19 @@
       "cell_type": "markdown",
       "id": "b05a4dfa-1763-431d-9027-75c783712e85",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(255, 167, 103, 0.25); padding: 5px;\">\n",
-        "    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n",
-        "        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/crystal-ball.png\" />\n",
-        "    </div>\n",
-        "    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n",
-        "        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n",
-        "        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Semantic Search with OpenAI QA</h1>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(255, 167, 103, 0.25); padding: 5px;\">\n    <div id=\"icon-image\" style=\"width: 90px; height: 90px;\">\n        <img width=\"100%\" height=\"100%\" src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/crystal-ball.png\" />\n    </div>\n    <div id=\"text\" style=\"padding: 5px; margin-left: 10px;\">\n        <div id=\"badge\" style=\"display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%\">SingleStore Notebooks</div>\n        <h1 style=\"font-weight: 500; margin: 8px 0 0 4px;\">Semantic Search with OpenAI QA</h1>\n    </div>\n</div>"
     },
     {
       "cell_type": "markdown",
       "id": "f801cd94-180c-4dea-b85c-67659aad0ea6",
       "metadata": {},
-      "source": [
-        "## Prerequisites for interacting with ChatGPT"
-      ]
+      "source": "## Prerequisites for interacting with ChatGPT"
     },
     {
       "cell_type": "markdown",
       "id": "df04d713-f330-4335-9837-3ab79eb552d6",
       "metadata": {},
-      "source": [
-        "### Install OpenAI package\n",
-        "\n",
-        "Let's start by installing the [openai](https://platform.openai.com/docs/api-reference?lang=python) Python package."
-      ]
+      "source": "### Install OpenAI package\n\nLet's start by installing the [openai](https://platform.openai.com/docs/api-reference?lang=python) Python package."
     },
     {
       "cell_type": "code",
@@ -40,17 +24,13 @@
       "id": "7690dc5e-93f4-477d-87b2-db35da95fb65",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip install openai --quiet"
-      ]
+      "source": "!pip install openai --quiet"
     },
     {
       "cell_type": "markdown",
       "id": "62bd45fa-daac-4d71-ab76-be014ddd3a32",
       "metadata": {},
-      "source": [
-        "### Connect to ChatGPT and display the response"
-      ]
+      "source": "### Connect to ChatGPT and display the response"
     },
     {
       "cell_type": "code",
@@ -58,20 +38,13 @@
       "id": "9c4378f4-02d4-4c19-a512-f3eed0a9cb88",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import openai\n",
-        "\n",
-        "EMBEDDING_MODEL = \"text-embedding-ada-002\"\n",
-        "GPT_MODEL = \"gpt-3.5-turbo\""
-      ]
+      "source": "import openai\n\nEMBEDDING_MODEL = \"text-embedding-ada-002\"\nGPT_MODEL = \"gpt-3.5-turbo\""
     },
     {
       "cell_type": "markdown",
       "id": "c244aa25-f548-47b2-8942-991552dc0ca1",
       "metadata": {},
-      "source": [
-        "You will need an OpenAI API key in order to use the the `openai` Python library."
-      ]
+      "source": "You will need an OpenAI API key in order to use the the `openai` Python library."
     },
     {
       "cell_type": "code",
@@ -79,17 +52,13 @@
       "id": "c2114aea-e137-407e-8e05-bf5688594a98",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "openai.api_key = '<ENTER YOUR OPEN AI KEY>'"
-      ]
+      "source": "openai.api_key = '<ENTER YOUR OPEN AI KEY>'"
     },
     {
       "cell_type": "markdown",
       "id": "0663c6f2-7741-4966-aea8-d5629e4a1cd4",
       "metadata": {},
-      "source": [
-        "Test the connection."
-      ]
+      "source": "Test the connection."
     },
     {
       "cell_type": "code",
@@ -97,33 +66,19 @@
       "id": "244f1d45-db89-489e-aad0-153a652d59f6",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "response = openai.ChatCompletion.create(\n",
-        "  model=GPT_MODEL,\n",
-        "  messages=[\n",
-        "        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
-        "        {\"role\": \"user\", \"content\": \"Who won the gold medal for curling in Olymics 2022?\"},\n",
-        "    ]\n",
-        ")\n",
-        "\n",
-        "print(response['choices'][0]['message']['content'])"
-      ]
+      "source": "response = openai.ChatCompletion.create(\n  model=GPT_MODEL,\n  messages=[\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": \"Who won the gold medal for curling in Olymics 2022?\"},\n    ]\n)\n\nprint(response['choices'][0]['message']['content'])"
     },
     {
       "cell_type": "markdown",
       "id": "d287b813-2885-4b22-a431-03c6b4eab058",
       "metadata": {},
-      "source": [
-        "# Get the data about Winter Olympics and provide the information to ChatGPT as context"
-      ]
+      "source": "# Get the data about Winter Olympics and provide the information to ChatGPT as context"
     },
     {
       "cell_type": "markdown",
       "id": "682326b6-a475-4d79-828d-951780a6fb96",
       "metadata": {},
-      "source": [
-        "## 1. Install and import libraries"
-      ]
+      "source": "## 1. Install and import libraries"
     },
     {
       "cell_type": "code",
@@ -131,14 +86,7 @@
       "id": "b5ef7c8a-7ab0-473d-b944-8cdbfe4918d8",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "!pip install matplotlib --quiet\n",
-        "!pip install plotly.express --quiet\n",
-        "!pip install scikit-learn --quiet\n",
-        "!pip install tabulate --quiet\n",
-        "!pip install tiktoken --quiet\n",
-        "!pip install wget --quiet"
-      ]
+      "source": "!pip install matplotlib --quiet\n!pip install plotly.express --quiet\n!pip install scikit-learn --quiet\n!pip install tabulate --quiet\n!pip install tiktoken --quiet\n!pip install wget --quiet"
     },
     {
       "cell_type": "code",
@@ -146,29 +94,19 @@
       "id": "a01f2552-cde3-49a4-8205-72b8fa8260c1",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import json\n",
-        "import numpy as np\n",
-        "import os\n",
-        "import pandas as pd\n",
-        "import wget"
-      ]
+      "source": "import json\nimport numpy as np\nimport os\nimport pandas as pd\nimport wget"
     },
     {
       "cell_type": "markdown",
       "id": "5f7aee40-4774-4ef1-b700-a83f9fed4fbb",
       "metadata": {},
-      "source": [
-        "## 2. Fetch the CSV data and read it into a DataFrame"
-      ]
+      "source": "## 2. Fetch the CSV data and read it into a DataFrame"
     },
     {
       "cell_type": "markdown",
       "id": "05fcb9a8-2290-4507-aad1-a3002cab0ba6",
       "metadata": {},
-      "source": [
-        "Download pre-chunked text and pre-computed embeddings. This file is ~200 MB, so may take a minute depending on your connection speed."
-      ]
+      "source": "Download pre-chunked text and pre-computed embeddings. This file is ~200 MB, so may take a minute depending on your connection speed."
     },
     {
       "cell_type": "code",
@@ -176,25 +114,13 @@
       "id": "bef09ede-40b1-40f3-9966-f68d4b025fbd",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "embeddings_url = \"https://cdn.openai.com/API/examples/data/winter_olympics_2022.csv\"\n",
-        "embeddings_path = \"winter_olympics_2022.csv\"\n",
-        "\n",
-        "if not os.path.exists(embeddings_path):\n",
-        "    wget.download(embeddings_url, embeddings_path)\n",
-        "    print(\"File downloaded successfully.\")\n",
-        "else:\n",
-        "    print(\"File already exists in the local file system.\")"
-      ]
+      "source": "embeddings_url = \"https://cdn.openai.com/API/examples/data/winter_olympics_2022.csv\"\nembeddings_path = \"winter_olympics_2022.csv\"\n\nif not os.path.exists(embeddings_path):\n    wget.download(embeddings_url, embeddings_path)\n    print(\"File downloaded successfully.\")\nelse:\n    print(\"File already exists in the local file system.\")"
     },
     {
       "cell_type": "markdown",
       "id": "1faf22b7-5b99-4a9b-a88a-24acb16d133e",
       "metadata": {},
-      "source": [
-        "Here we are using the `converters=` parameter of the `pd.read_csv` function to convert the JSON\n",
-        "array in the CSV file to numpy arrays."
-      ]
+      "source": "Here we are using the `converters=` parameter of the `pd.read_csv` function to convert the JSON\narray in the CSV file to numpy arrays."
     },
     {
       "cell_type": "code",
@@ -202,14 +128,7 @@
       "id": "6e0669bf-9070-42bd-a561-f6729f9203a6",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "def json_to_numpy_array(x: str | None) -> np.ndarray | None:\n",
-        "    \"\"\"Convert JSON array string into numpy array.\"\"\"\n",
-        "    return np.array(json.loads(x)) if x else None\n",
-        "\n",
-        "df = pd.read_csv(embeddings_path, converters=dict(embedding=json_to_numpy_array))\n",
-        "df"
-      ]
+      "source": "def json_to_numpy_array(x: str | None) -> np.ndarray | None:\n    \"\"\"Convert JSON array string into numpy array.\"\"\"\n    return np.array(json.loads(x)) if x else None\n\ndf = pd.read_csv(embeddings_path, converters=dict(embedding=json_to_numpy_array))\ndf"
     },
     {
       "cell_type": "code",
@@ -217,84 +136,57 @@
       "id": "bcf14e64-982e-465b-8e2b-6239650b2f51",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "df.info(show_counts=True)"
-      ]
+      "source": "df.info(show_counts=True)"
     },
     {
       "cell_type": "markdown",
       "id": "cb523f8c-78b2-4a75-be15-52d29fac0fff",
       "metadata": {},
-      "source": [
-        "## 3. Set up the database"
-      ]
+      "source": "## 3. Set up the database"
     },
     {
       "cell_type": "markdown",
       "id": "ca811e5f-6dcd-471b-a4de-03eab42acf4f",
       "metadata": {},
-      "source": [
-        "Create the database."
-      ]
+      "source": "Create the database."
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "ca33b770-95f9-47ae-9509-5dd98c331037",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "DROP DATABASE IF EXISTS winter_wikipedia;\n",
-        "\n",
-        "CREATE DATABASE winter_wikipedia;"
-      ]
+      "source": "DROP DATABASE IF EXISTS winter_wikipedia;\n\nCREATE DATABASE winter_wikipedia;"
     },
     {
       "cell_type": "markdown",
       "id": "393e0d4a-8020-447e-b0ae-aa4199b1a016",
       "metadata": {},
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n",
-        "    <div>\n",
-        "        <p><b>Action Required</b></p>\n",
-        "        <p>Make sure to select the <tt>winter_wikipedia</tt> database from the drop-down menu at the top of this notebook.\n",
-        "        It updates the <tt>connection_url</tt> which is used by the <tt>%%sql</tt> magic command and SQLAlchemy to make connections to the selected database.</p>\n",
-        "    </div>\n",
-        "</div>"
-      ]
+      "source": "<div class=\"alert alert-block alert-warning\">\n    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n    <div>\n        <p><b>Action Required</b></p>\n        <p>Make sure to select the <tt>winter_wikipedia</tt> database from the drop-down menu at the top of this notebook.\n        It updates the <tt>connection_url</tt> which is used by SQLAlchemy to make connections to the selected database.</p>\n    </div>\n</div>"
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "011afdb9-cbd4-42af-8121-a8928d5c8432",
-      "metadata": {},
+      "metadata": {
+        "language": "sql"
+      },
       "outputs": [],
-      "source": [
-        "%%sql\n",
-        "CREATE TABLE IF NOT EXISTS winter_olympics_2022 (\n",
-        "    id INT PRIMARY KEY,\n",
-        "    text TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,\n",
-        "    embedding BLOB\n",
-        ");"
-      ]
+      "source": "CREATE TABLE IF NOT EXISTS winter_olympics_2022 (\n    id INT PRIMARY KEY,\n    text TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,\n    embedding BLOB\n);"
     },
     {
       "cell_type": "markdown",
       "id": "6b7ab530-4f55-482f-8e4c-475df06fe9b3",
       "metadata": {},
-      "source": [
-        "## 4. Populate the table with our DataFrame"
-      ]
+      "source": "## 4. Populate the table with our DataFrame"
     },
     {
       "cell_type": "markdown",
       "id": "51be94b1-9901-499c-a364-c85782239e2a",
       "metadata": {},
-      "source": [
-        "Create a SQLAlchemy connection."
-      ]
+      "source": "Create a SQLAlchemy connection."
     },
     {
       "cell_type": "code",
@@ -302,19 +194,13 @@
       "id": "b8722e7e-211e-44a6-b512-eee1719c2879",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import singlestoredb as s2\n",
-        "\n",
-        "db_connection = s2.create_engine().connect()"
-      ]
+      "source": "import singlestoredb as s2\n\ndb_connection = s2.create_engine().connect()"
     },
     {
       "cell_type": "markdown",
       "id": "2ce8c4c5-f389-4d0d-b434-6cd628343688",
       "metadata": {},
-      "source": [
-        "Use the `to_sql` method of the DataFrame to upload the data to the requested table."
-      ]
+      "source": "Use the `to_sql` method of the DataFrame to upload the data to the requested table."
     },
     {
       "cell_type": "code",
@@ -322,17 +208,13 @@
       "id": "8dd44f53-f6ec-4009-8d1d-95209d704eec",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "df.to_sql('winter_olympics_2022', con=db_connection, index=True, index_label='id', if_exists='append', chunksize=1000)"
-      ]
+      "source": "df.to_sql('winter_olympics_2022', con=db_connection, index=True, index_label='id', if_exists='append', chunksize=1000)"
     },
     {
       "cell_type": "markdown",
       "id": "c4d4602c-bfec-4819-904b-4d376b920e44",
       "metadata": {},
-      "source": [
-        "## 5. Do a semantic search with the same question from above and use the response to send to OpenAI again"
-      ]
+      "source": "## 5. Do a semantic search with the same question from above and use the response to send to OpenAI again"
     },
     {
       "cell_type": "code",
@@ -340,45 +222,7 @@
       "id": "e8560501-ff5e-4727-8d07-99f2173a3d62",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "from openai.embeddings_utils import get_embedding\n",
-        "\n",
-        "\n",
-        "def strings_ranked_by_relatedness(\n",
-        "    query: str,\n",
-        "    df: pd.DataFrame,\n",
-        "    table_name: str,\n",
-        "    relatedness_fn=lambda x, y: 1 - spatial.distance.cosine(x, y),\n",
-        "    top_n: int=100,\n",
-        ") -> tuple:\n",
-        "    \"\"\"Returns a list of strings and relatednesses, sorted from most related to least.\"\"\"\n",
-        "\n",
-        "    # Get the embedding of the query.\n",
-        "    query_embedding_response = get_embedding(query, EMBEDDING_MODEL)\n",
-        "\n",
-        "    # Create the SQL statement.\n",
-        "    stmt = f\"\"\"\n",
-        "        SELECT\n",
-        "            text,\n",
-        "            DOT_PRODUCT_F64(JSON_ARRAY_PACK_F64(%s), embedding) AS score\n",
-        "        FROM {table_name}\n",
-        "        ORDER BY score DESC\n",
-        "        LIMIT %s\n",
-        "    \"\"\"\n",
-        "\n",
-        "    # Execute the SQL statement.\n",
-        "    results = db_connection.execute(stmt, [json.dumps(query_embedding_response), top_n])\n",
-        "\n",
-        "    strings = []\n",
-        "    relatednesses = []\n",
-        "\n",
-        "    for row in results:\n",
-        "        strings.append(row[0])\n",
-        "        relatednesses.append(row[1])\n",
-        "\n",
-        "    # Return the results.\n",
-        "    return strings[:top_n], relatednesses[:top_n]"
-      ]
+      "source": "from openai.embeddings_utils import get_embedding\n\n\ndef strings_ranked_by_relatedness(\n    query: str,\n    df: pd.DataFrame,\n    table_name: str,\n    relatedness_fn=lambda x, y: 1 - spatial.distance.cosine(x, y),\n    top_n: int=100,\n) -> tuple:\n    \"\"\"Returns a list of strings and relatednesses, sorted from most related to least.\"\"\"\n\n    # Get the embedding of the query.\n    query_embedding_response = get_embedding(query, EMBEDDING_MODEL)\n\n    # Create the SQL statement.\n    stmt = f\"\"\"\n        SELECT\n            text,\n            DOT_PRODUCT_F64(JSON_ARRAY_PACK_F64(%s), embedding) AS score\n        FROM {table_name}\n        ORDER BY score DESC\n        LIMIT %s\n    \"\"\"\n\n    # Execute the SQL statement.\n    results = db_connection.execute(stmt, [json.dumps(query_embedding_response), top_n])\n\n    strings = []\n    relatednesses = []\n\n    for row in results:\n        strings.append(row[0])\n        relatednesses.append(row[1])\n\n    # Return the results.\n    return strings[:top_n], relatednesses[:top_n]"
     },
     {
       "cell_type": "code",
@@ -386,21 +230,7 @@
       "id": "a1b27188-409c-4e43-8065-5448f40e1986",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "from tabulate import tabulate\n",
-        "\n",
-        "strings, relatednesses = strings_ranked_by_relatedness(\n",
-        "    \"curling gold medal\",\n",
-        "    df,\n",
-        "    \"winter_olympics_2022\",\n",
-        "    top_n=5\n",
-        ")\n",
-        "\n",
-        "for string, relatedness in zip(strings, relatednesses):\n",
-        "    print(f\"{relatedness=:.3f}\")\n",
-        "    print(tabulate([[string]], headers=['Result'], tablefmt='fancy_grid'))\n",
-        "    print('\\n\\n')"
-      ]
+      "source": "from tabulate import tabulate\n\nstrings, relatednesses = strings_ranked_by_relatedness(\n    \"curling gold medal\",\n    df,\n    \"winter_olympics_2022\",\n    top_n=5\n)\n\nfor string, relatedness in zip(strings, relatednesses):\n    print(f\"{relatedness=:.3f}\")\n    print(tabulate([[string]], headers=['Result'], tablefmt='fancy_grid'))\n    print('\\n\\n')"
     },
     {
       "cell_type": "code",
@@ -408,62 +238,7 @@
       "id": "ce7411d2-6f3c-408b-996b-2ec34cad5d7d",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import tiktoken\n",
-        "\n",
-        "\n",
-        "def num_tokens(text: str, model: str=GPT_MODEL) -> int:\n",
-        "    \"\"\"Return the number of tokens in a string.\"\"\"\n",
-        "    encoding = tiktoken.encoding_for_model(model)\n",
-        "    return len(encoding.encode(text))\n",
-        "\n",
-        "\n",
-        "def query_message(\n",
-        "    query: str,\n",
-        "    df: pd.DataFrame,\n",
-        "    model: str,\n",
-        "    token_budget: int\n",
-        ") -> str:\n",
-        "    \"\"\"Return a message for GPT, with relevant source texts pulled from SingleStoreDB.\"\"\"\n",
-        "    strings, relatednesses = strings_ranked_by_relatedness(query, df, \"winter_olympics_2022\")\n",
-        "    introduction = 'Use the below articles on the 2022 Winter Olympics to answer the subsequent question. If the answer cannot be found in the articles, write \"I could not find an answer.\"'\n",
-        "    question = f\"\\n\\nQuestion: {query}\"\n",
-        "    message = introduction\n",
-        "    for string in strings:\n",
-        "        next_article = f'\\n\\nWikipedia article section:\\n\"\"\"\\n{string}\\n\"\"\"'\n",
-        "        if (\n",
-        "            num_tokens(message + next_article + question, model=model)\n",
-        "            > token_budget\n",
-        "        ):\n",
-        "            break\n",
-        "        else:\n",
-        "            message += next_article\n",
-        "    return message + question\n",
-        "\n",
-        "\n",
-        "def ask(\n",
-        "    query: str,\n",
-        "    df: pd.DataFrame=df,\n",
-        "    model: str=GPT_MODEL,\n",
-        "    token_budget: int=4096 - 500,\n",
-        "    print_message: bool=False,\n",
-        ") -> str:\n",
-        "    \"\"\"Answers a query using GPT and a table of relevant texts and embeddings in SingleStoreDB.\"\"\"\n",
-        "    message = query_message(query, df, model=model, token_budget=token_budget)\n",
-        "    if print_message:\n",
-        "        print(message)\n",
-        "    messages = [\n",
-        "        {\"role\": \"system\", \"content\": \"You answer questions about the 2022 Winter Olympics.\"},\n",
-        "        {\"role\": \"user\", \"content\": message},\n",
-        "    ]\n",
-        "    response = openai.ChatCompletion.create(\n",
-        "        model=model,\n",
-        "        messages=messages,\n",
-        "        temperature=0\n",
-        "    )\n",
-        "    response_message = response[\"choices\"][0][\"message\"][\"content\"]\n",
-        "    return response_message"
-      ]
+      "source": "import tiktoken\n\n\ndef num_tokens(text: str, model: str=GPT_MODEL) -> int:\n    \"\"\"Return the number of tokens in a string.\"\"\"\n    encoding = tiktoken.encoding_for_model(model)\n    return len(encoding.encode(text))\n\n\ndef query_message(\n    query: str,\n    df: pd.DataFrame,\n    model: str,\n    token_budget: int\n) -> str:\n    \"\"\"Return a message for GPT, with relevant source texts pulled from SingleStoreDB.\"\"\"\n    strings, relatednesses = strings_ranked_by_relatedness(query, df, \"winter_olympics_2022\")\n    introduction = 'Use the below articles on the 2022 Winter Olympics to answer the subsequent question. If the answer cannot be found in the articles, write \"I could not find an answer.\"'\n    question = f\"\\n\\nQuestion: {query}\"\n    message = introduction\n    for string in strings:\n        next_article = f'\\n\\nWikipedia article section:\\n\"\"\"\\n{string}\\n\"\"\"'\n        if (\n            num_tokens(message + next_article + question, model=model)\n            > token_budget\n        ):\n            break\n        else:\n            message += next_article\n    return message + question\n\n\ndef ask(\n    query: str,\n    df: pd.DataFrame=df,\n    model: str=GPT_MODEL,\n    token_budget: int=4096 - 500,\n    print_message: bool=False,\n) -> str:\n    \"\"\"Answers a query using GPT and a table of relevant texts and embeddings in SingleStoreDB.\"\"\"\n    message = query_message(query, df, model=model, token_budget=token_budget)\n    if print_message:\n        print(message)\n    messages = [\n        {\"role\": \"system\", \"content\": \"You answer questions about the 2022 Winter Olympics.\"},\n        {\"role\": \"user\", \"content\": message},\n    ]\n    response = openai.ChatCompletion.create(\n        model=model,\n        messages=messages,\n        temperature=0\n    )\n    response_message = response[\"choices\"][0][\"message\"][\"content\"]\n    return response_message"
     },
     {
       "cell_type": "code",
@@ -471,18 +246,13 @@
       "id": "46a21d10-88bb-4cfb-b68d-b4a5b12ba1f4",
       "metadata": {},
       "outputs": [],
-      "source": [
-        "print(ask('Who won the gold medal for curling in Olymics 2022?'))"
-      ]
+      "source": "print(ask('Who won the gold medal for curling in Olymics 2022?'))"
     },
     {
       "cell_type": "markdown",
       "id": "30cca5fc-9cf5-474b-820f-440255193976",
       "metadata": {},
-      "source": [
-        "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",
-        "<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
-      ]
+      "source": "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n<div><img src=\"https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png\" style=\"padding: 0px; margin: 0px; height: 24px\"/></div>"
     }
   ],
   "metadata": {
@@ -501,7 +271,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.3"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,

--- a/resources/nb-check.py
+++ b/resources/nb-check.py
@@ -72,7 +72,7 @@ def error(msg: str) -> None:
     sys.exit(1)
 
 
-def new_markdown_cell(cell_id: str, content: list[str]) -> dict[str, Any]:
+def new_markdown_cell(cell_id: str, content: str) -> dict[str, Any]:
     """
     Construct a markdown cell for a notebook.
 

--- a/resources/nb-check.py
+++ b/resources/nb-check.py
@@ -9,22 +9,9 @@ import uuid
 from typing import Any
 
 
-NOTEBOOK_HEADER = [
-    '<div id="singlestore-header" style="display: flex; background-color: {background_color}; padding: 5px;">\n',
-    '    <div id="icon-image" style="width: 90px; height: 90px;">\n',
-    '        <img width="100%" height="100%" src="https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/{icon_name}.png" />\n',
-    '    </div>\n',
-    '    <div id="text" style="padding: 5px; margin-left: 10px;">\n',
-    '        <div id="badge" style="display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%">SingleStore Notebooks</div>\n',
-    '        <h1 style="font-weight: 500; margin: 8px 0 0 4px;">{title}</h1>\n',
-    '    </div>\n',
-    '</div>',
-]
+NOTEBOOK_HEADER = '<div id="singlestore-header" style="display: flex; background-color: {background_color}; padding: 5px;">\n    <div id="icon-image" style="width: 90px; height: 90px;">\n        <img width="100%" height="100%" src="https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/header-icons/{icon_name}.png" />\n    </div>\n    <div id="text" style="padding: 5px; margin-left: 10px;">\n        <div id="badge" style="display: inline-block; background-color: rgba(0, 0, 0, 0.15); border-radius: 4px; padding: 4px 8px; align-items: center; margin-top: 6px; margin-bottom: -2px; font-size: 80%">SingleStore Notebooks</div>\n        <h1 style="font-weight: 500; margin: 8px 0 0 4px;">{title}</h1>\n    </div>\n</div>'
 
-NOTEBOOK_FOOTER = [
-    '<div id="singlestore-footer" style="background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px"></div>\n',
-    '<div><img src="https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png" style="padding: 0px; margin: 0px; height: 24px"/></div>',
-]
+NOTEBOOK_FOOTER = '<div id="singlestore-footer" style="background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px"></div>\n<div><img src="https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/common/images/singlestore-logo-grey.png" style="padding: 0px; margin: 0px; height: 24px"/></div>'
 
 ICON_COLORS = {
     'arrow-up-right-dots': 'rgba(255, 167, 103, 0.25)',

--- a/resources/nb-check.py
+++ b/resources/nb-check.py
@@ -177,10 +177,10 @@ for f in sys.argv[1:]:
 
     # Add header cell
     header = NOTEBOOK_HEADER.format(
-            background_color=background_color,
-            icon_name=icon_name,
-            title=title,
-        )
+        background_color=background_color,
+        icon_name=icon_name,
+        title=title,
+    )
     cells.insert(0, new_markdown_cell(header_id, header))
 
     # Add footer cell

--- a/resources/nb-check.py
+++ b/resources/nb-check.py
@@ -123,7 +123,13 @@ for f in sys.argv[1:]:
     # Clear out execution metadata and cell output
     for cell in cells:
         if 'metadata' in cell:
-            cell['metadata'] = {}
+            clean_metadata = {}
+            if 'language' in cell['metadata']:
+                clean_metadata['language'] = cell['metadata']['language']
+            if 'output_variable' in cell['metadata']:
+                clean_metadata['output_variable'] = cell['metadata']['output_variable']
+
+            cell['metadata'] = clean_metadata
         if 'outputs' in cell:
             cell['outputs'] = []
         if 'execution_count' in cell:

--- a/resources/nb-check.py
+++ b/resources/nb-check.py
@@ -80,7 +80,7 @@ def new_markdown_cell(cell_id: str, content: str) -> dict[str, Any]:
     ----------
     cell_id : str
         The UUID to use for the cell ID
-    content : list[str]
+    content : str
         The list of strings that make up the cell contents
 
     Returns
@@ -170,13 +170,11 @@ for f in sys.argv[1:]:
         error(f'missing title in {toml_path}')
 
     # Add header cell
-    header = [
-        x.format(
+    header = NOTEBOOK_HEADER.format(
             background_color=background_color,
             icon_name=icon_name,
             title=title,
-        ) for x in NOTEBOOK_HEADER
-    ]
+        )
     cells.insert(0, new_markdown_cell(header_id, header))
 
     # Add footer cell


### PR DESCRIPTION
The JupyterLab version for notebooks will be updated to version `4.0.4`. In JupyterLab 4, the source code of a cell is saved as a single string (likely related to the CodeMirror upgrade). Before, it was an array of strings where each string represented a line of code. Although JupyterLab 4 is still able to read these old notebook files, it seems to append a newline at the end of each string in the array. As a result, every newline in the old notebook gets duplicated. As such, this MR updates the template notebooks to turn the `source` array of string into a single string.

Additionally,  notebooks will now support SQL cells, which are cells specified to run SQL without the need to pre-pend the magic command (i.e. `%%sql`). To mark a cell as SQL, its metadata needs to contain `language: "sql"`. In the case where a cell used to output the results to a variable, the metadata must also contain `output_variable: "<variable>"`. The notebooks were therefore updated to:
- remove the SQL magic;
- update these cells' metadata accordingly;
- re-word explanation text to mention SQL cell instead of the magic command.

I only updated the SQL cells of notebooks which are currently on the Portal template list.

**Note:** There will likely also be a further update to the `Image Matching with SQL` notebook, since `boto3` is broken with the new JupyterLab4 upgrade due to an incompatibility with the new version of `urllib`. A solution for this has not been decided yet.