### PR TITLE
Remove duplicated benchmark tag

### DIFF
--- a/notebooks/optimize-performance-with-tpch-100/meta.toml
+++ b/notebooks/optimize-performance-with-tpch-100/meta.toml
@@ -4,5 +4,5 @@ description="""\
     This notebook will help you understand how you can take advantage of SingleStoreDB distributed capability using TPCH-100.
 """
 icon="database"
-tags=["performance", "benchmark", "tpch", "benchmark", "shardkey", "ingest"]
+tags=["performance", "benchmark", "tpch", "shardkey", "ingest"]
 destinations=["spaces"]


### PR DESCRIPTION
The Optimize Performance notebook has the tag "benchmark" duplicated. I'm removing one.