### PR TITLE
Fix LLM notebook

### DIFF
--- a/notebooks/how-to-build-llm-apps-that-can-see-hear-speak/notebook.ipynb
+++ b/notebooks/how-to-build-llm-apps-that-can-see-hear-speak/notebook.ipynb
@@ -24,7 +24,7 @@
         "<a name=\"architecture\"></a>\n",
         "\n",
         "# Demo Architecture\n",
-        "![Image Alt Text](https://drive.google.com/uc?id=14LYlMDIroDDXHel4hCaOR1EFg_BuYb9P)"
+        "![Image Alt Text](https://drive.usercontent.google.com/download?id=14LYlMDIroDDXHel4hCaOR1EFg_BuYb9P)"
       ]
     },
     {


### PR DESCRIPTION
Image is not rendering on singlestore.com (maybe because its a redirect)

https://www.singlestore.com/spaces/how-to-build-llm-apps-that-can-see-hear-speak/

Change it to the resolved image URL