### PR TITLE
initial insert, SP for 10M vecs, comment for 160M vecs

### DIFF
--- a/notebooks/searching-all-of-wikipedia/notebook.ipynb
+++ b/notebooks/searching-all-of-wikipedia/notebook.ipynb
@@ -53,7 +53,7 @@
         "For the purposes of this demo, we are only generating 10 million vectors to search through. By our estimations, Wikipedia contains around 160 million paragraphs as a whole. A quick heuristic for your workspace sizing:\n",
         "\n",
         "- 160 million vectors can be handled by an S-32 Workspace\n",
-        "- 20 million vectors van be handled by an S-4 Workspace\n",
+        "- 20 million vectors can be handled by an S-4 Workspace\n",
         "\n",
         "You can now extrapolate the workspace size you require from the number of vectors you want to generate!"
       ]
@@ -229,7 +229,16 @@
         "%%sql\n",
         "-- run the procedure to populate `vecs` with 10,000,000 vectors\n",
         "-- this will take around 20 min\n",
-        "call insert_vectors(130000);"
+        "insert into vecs (id, v) values (0, nrandv1536());\n",
+        "call insert_vectors(10000000);"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a29162bb",
+      "metadata": {},
+      "source": [
+        "As a quick aside, if you want to generate the full 160 million vectors, you simply have to change the `num_rows` to 160,000,000: `call insert_vectors(160000000);`"
       ]
     },
     {


### PR DESCRIPTION
Fixed SP error: nothing is written to the table using the SP `insert_vectors` if the table is empty. Added a line to initialize one row to the table so that the procedure works. Added comments/wording errors. 