### PR TITLE
Fix typo in Notebook description

### DIFF
--- a/notebooks/how-to-build-llm-apps-that-can-see-hear-speak/meta.toml
+++ b/notebooks/how-to-build-llm-apps-that-can-see-hear-speak/meta.toml
@@ -1,7 +1,7 @@
 [meta]
 title="How to Build LLM Apps that can See Hear Speak"
 description="""\
-    Using OpenAI to build a an app that can take images, audio, and text data to generate output
+    Using OpenAI to build an app that can take images, audio, and text data to generate output
     """
 icon="chart-network"
 tags=["advanced", "openai", "genai", "vectordb"]


### PR DESCRIPTION
This PR fixes a small typo in the description of the Space "How to Build LLM Apps that can See Hear Speak"