### PR TITLE
Update release process

### DIFF
--- a/.github/workflows/release-samples.yml
+++ b/.github/workflows/release-samples.yml
@@ -1,10 +1,9 @@
-name: Upload Release Asset
+name: Upload Release Assets
 
 on:
   push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+    branches:
+      - "master"
 
 jobs:
   build:

--- a/.github/workflows/release-samples.yml
+++ b/.github/workflows/release-samples.yml
@@ -24,7 +24,6 @@ jobs:
 
       - name: Build notebooks
         run: |
-          python resources/package-samples.py notebooks --strip-output --outfile sample-notebooks.zip --notebooks sample
           python resources/package-samples.py notebooks --strip-output --outfile notebooks-stripped.zip --notebooks all
           python resources/package-samples.py notebooks --outfile notebooks-full.zip --notebooks all
 
@@ -43,16 +42,6 @@ jobs:
       # it's ID to get its outputs object, which include a `upload_url`.
       # See this blog post for more info:
       #   https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-      - name: Upload Sample Asset
-        id: upload-sample-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./sample-notebooks.zip
-          asset_name: sample-notebooks.zip
-          asset_content_type: application/zip
       - name: Upload Stripped Asset
         id: upload-stripped-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-samples.yml
+++ b/.github/workflows/release-samples.yml
@@ -33,8 +33,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{ github.sha }}
+          release_name: Release ${{ github.sha }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/release-samples.yml
+++ b/.github/workflows/release-samples.yml
@@ -3,7 +3,7 @@ name: Upload Release Assets
 on:
   push:
     branches:
-      - "master"
+      - master
 
 jobs:
   build:

--- a/.github/workflows/release-samples.yml
+++ b/.github/workflows/release-samples.yml
@@ -4,7 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   build:
@@ -23,9 +23,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
 
-      - name: Build project
+      - name: Build notebooks
         run: |
-          python resources/package-samples.py notebooks
+          python resources/package-samples.py notebooks --strip-output --outfile sample-notebooks.zip --notebooks sample
+          python resources/package-samples.py notebooks --strip-output --outfile notebooks-stripped.zip --notebooks all
+          python resources/package-samples.py notebooks --outfile notebooks-full.zip --notebooks all
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release-samples.yml
+++ b/.github/workflows/release-samples.yml
@@ -40,17 +40,37 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload Release Asset
-        id: upload-release-asset
+      # This pulls from the CREATE RELEASE step above, referencing
+      # it's ID to get its outputs object, which include a `upload_url`.
+      # See this blog post for more info:
+      #   https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+      - name: Upload Sample Asset
+        id: upload-sample-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # This pulls from the CREATE RELEASE step above, referencing
-          # it's ID to get its outputs object, which include a `upload_url`.
-          # See this blog post for more info:
-          #   https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./sample-notebooks.zip
           asset_name: sample-notebooks.zip
+          asset_content_type: application/zip
+      - name: Upload Stripped Asset
+        id: upload-stripped-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./notebooks-stripped.zip
+          asset_name: notebooks-stripped.zip
+          asset_content_type: application/zip
+      - name: Upload Full Asset
+        id: upload-stripped-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./notebooks-full.zip
+          asset_name: notebooks-full.zip
           asset_content_type: application/zip

--- a/resources/nb-check.py
+++ b/resources/nb-check.py
@@ -145,12 +145,10 @@ for f in sys.argv[1:]:
 
     cells = nb.get('cells', [])
 
-    # Remove metadata and outputs
+    # Remove metadata
     for i, cell in enumerate(cells):
         if 'metadata' in cell:
             cell['metadata'] = {}
-        if 'outputs' in cell:
-            cell['outputs'] = []
 
     # Remove empty cells at the end of the notebook
     end = len(cells) - 1

--- a/resources/package-samples.py
+++ b/resources/package-samples.py
@@ -144,7 +144,7 @@ if __name__ == '__main__':
                     out.write(source, arcname=destination)
 
             if args.strip_outputs:
-                # overwrite notebook file with stripped output version
+                # write notebook with stripped output
                 destination = os.path.join(
                     notebook_name,
                     NOTEBOOK_FILE_NAME

--- a/resources/package-samples.py
+++ b/resources/package-samples.py
@@ -139,8 +139,8 @@ if __name__ == '__main__':
 
                     if source == notebook_path and args.strip_outputs:
                         # write notebook with stripped output
-                        contents = strip_outputs(notebook_path)
-                        out.writestr(destination, contents)
+                        stripped_nodebook = strip_outputs(notebook_path)
+                        out.writestr(destination, stripped_nodebook)
                     else:
                         # write file normally
                         out.write(source, arcname=destination)

--- a/resources/package-samples.py
+++ b/resources/package-samples.py
@@ -11,6 +11,7 @@ NOTEBOOK_FILE_NAME = 'notebook.ipynb'
 
 REQUIRED_FILES = [NOTEBOOK_FILE_NAME, 'meta.toml']
 
+
 def strip_outputs(path: str) -> str:
     """Remove outputs from notebook at path."""
 
@@ -74,6 +75,7 @@ def convert_to_destination_path(path: str) -> str:
     filtered_parts = list(filter(lambda x: x != 'notebooks', parts))
 
     return '/'.join(filtered_parts)
+
 
 if __name__ == '__main__':
 

--- a/resources/package-samples.py
+++ b/resources/package-samples.py
@@ -29,7 +29,7 @@ def strip_outputs(path: str) -> str:
         return json.dumps(nb, indent=2)
 
 
-def get_valid_notebooks(notebooks: str | list[str], notebooks_directory: str) -> list[str]:
+def get_valid_notebooks(notebooks: str, notebooks_directory: str) -> list[str]:
     """Return a list of valid notebooks"""
 
     notebook_names = []
@@ -41,9 +41,9 @@ def get_valid_notebooks(notebooks: str | list[str], notebooks_directory: str) ->
     elif notebooks == "all":
         # get all
         notebook_names = os.listdir(notebooks_directory)
-    elif isinstance(object, list):
-        # return
-        notebook_names = notebooks
+    else:
+        # comma-separated list
+        notebook_names = list(map(str.strip, notebooks.split(',')))
 
     valid_notebooks = []
 

--- a/resources/package-samples.py
+++ b/resources/package-samples.py
@@ -137,17 +137,10 @@ if __name__ == '__main__':
                     source = os.path.join(dirpath, file)
                     destination = convert_to_destination_path(source)
 
-                    if args.strip_outputs and source == notebook_path:
-                        # don't write notebook here, will be written later after
-                        # transformation
-                        continue
-
-                    out.write(source, arcname=destination)
-
-            if args.strip_outputs:
-                # write notebook with stripped output
-
-                destination = convert_to_destination_path(notebook_path)
-
-                contents = strip_outputs(notebook_path)
-                out.writestr(destination, contents)
+                    if source == notebook_path and args.strip_outputs:
+                        # write notebook with stripped output
+                        contents = strip_outputs(notebook_path)
+                        out.writestr(destination, contents)
+                    else:
+                        # write file normally
+                        out.write(source, arcname=destination)

--- a/resources/package-samples.py
+++ b/resources/package-samples.py
@@ -7,9 +7,9 @@ import sys
 import tomllib
 from zipfile import ZipFile
 
-NOTEBOOK_FILE_NAME = "notebook.ipynb"
+NOTEBOOK_FILE_NAME = 'notebook.ipynb'
 
-REQUIRED_FILES = [NOTEBOOK_FILE_NAME, "meta.toml"]
+REQUIRED_FILES = [NOTEBOOK_FILE_NAME, 'meta.toml']
 
 def strip_outputs(path: str) -> str:
     """Remove outputs from notebook at path."""
@@ -34,11 +34,11 @@ def get_valid_notebooks(notebooks: str, notebooks_directory: str) -> list[str]:
 
     notebook_names = []
 
-    if notebooks == "sample":
+    if notebooks == 'sample':
         with open(args.toml, 'rb') as f:
             meta = tomllib.load(f)
             notebook_names = meta['samples']['display']
-    elif notebooks == "all":
+    elif notebooks == 'all':
         # get all
         notebook_names = os.listdir(notebooks_directory)
     else:
@@ -70,10 +70,10 @@ def get_valid_notebooks(notebooks: str, notebooks_directory: str) -> list[str]:
 
 def convert_to_destination_path(path: str) -> str:
     """Remove 'notebooks' from path"""
-    parts = path.split("/")
-    filtered_parts = list(filter(lambda x: x != "notebooks", parts))
+    parts = path.split('/')
+    filtered_parts = list(filter(lambda x: x != 'notebooks', parts))
 
-    return "/".join(filtered_parts)
+    return '/'.join(filtered_parts)
 
 if __name__ == '__main__':
 

--- a/resources/package-samples.py
+++ b/resources/package-samples.py
@@ -83,7 +83,8 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        'notebooks_directory', metavar='notebooks-directory',
+        'notebooks_directory',
+        metavar='notebooks-directory',
         help='root `notebooks` directory',
     )
     parser.add_argument(
@@ -127,7 +128,7 @@ if __name__ == '__main__':
 
             notebook_path = os.path.join(
                 notebook_directory_path,
-                NOTEBOOK_FILE_NAME
+                NOTEBOOK_FILE_NAME,
             )
 
             # write the whole notebook directory
@@ -147,7 +148,7 @@ if __name__ == '__main__':
                 # write notebook with stripped output
                 destination = os.path.join(
                     notebook_name,
-                    NOTEBOOK_FILE_NAME
+                    NOTEBOOK_FILE_NAME,
                 )
 
                 contents = strip_outputs(notebook_path)

--- a/resources/package-samples.py
+++ b/resources/package-samples.py
@@ -7,24 +7,73 @@ import sys
 import tomllib
 from zipfile import ZipFile
 
+NOTEBOOK_FILE_NAME = "notebook.ipynb"
 
-def read_file(path: str, strip_outputs: bool) -> str:
+REQUIRED_FILES = [NOTEBOOK_FILE_NAME, "meta.toml"]
+
+def strip_outputs(path: str) -> str:
     """Remove outputs from notebook at path."""
+
     with open(path, 'r') as infile:
         nb = json.loads(infile.read())
 
-        if strip_outputs:
-            for cell in nb['cells']:
-                if 'metadata' in cell:
-                    cell['metadata']['execution'] = {}
-                if 'outputs' in cell:
-                    cell['outputs'] = []
-                if 'metadata' in nb:
-                    if 'singlestore_connection' in nb['metadata']:
-                        nb['metadata']['singlestore_connection'] = {}
+        for cell in nb['cells']:
+            if 'metadata' in cell:
+                cell['metadata']['execution'] = {}
+            if 'outputs' in cell:
+                cell['outputs'] = []
+            if 'metadata' in nb:
+                if 'singlestore_connection' in nb['metadata']:
+                    nb['metadata']['singlestore_connection'] = {}
 
         return json.dumps(nb, indent=2)
 
+
+def get_valid_notebooks(notebooks: str | list[str], notebooks_directory: str) -> list[str]:
+    """Return a list of valid notebooks"""
+
+    notebook_names = []
+
+    if notebooks == "sample":
+        with open(args.toml, 'rb') as f:
+            meta = tomllib.load(f)
+            notebook_names = meta['samples']['display']
+    elif notebooks == "all":
+        # get all
+        notebook_names = os.listdir(notebooks_directory)
+    elif isinstance(object, list):
+        # return
+        notebook_names = notebooks
+
+    valid_notebooks = []
+
+    for notebook_name in notebook_names:
+
+        for required_file in REQUIRED_FILES:
+            path = os.path.join(
+                args.notebooks_directory,
+                notebook_name,
+                required_file,
+            )
+
+            if not os.path.isfile(path):
+                print(
+                    f'error: Required file does not exist: {path}',
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+        valid_notebooks.append(notebook_name)
+
+    return valid_notebooks
+
+
+def convert_to_destination_path(path: str) -> str:
+    """Remove 'notebooks' from path"""
+    parts = path.split("/")
+    filtered_parts = list(filter(lambda x: x != "notebooks", parts))
+
+    return "/".join(filtered_parts)
 
 if __name__ == '__main__':
 
@@ -36,6 +85,12 @@ if __name__ == '__main__':
     parser.add_argument(
         'notebooks_directory', metavar='notebooks-directory',
         help='root `notebooks` directory',
+    )
+    parser.add_argument(
+        '--notebooks',
+        help='which notebooks to package',
+        default='all',
+        required=True,
     )
     parser.add_argument(
         '-t', '--toml',
@@ -56,54 +111,46 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    with open(args.toml, 'rb') as f:
-        meta = tomllib.load(f)
-        files = []
-
-        for i, name in enumerate(meta['samples']['display']):
-
-            # Verify the notebook file exists
-            path = os.path.join(
-                args.notebooks_directory,
-                name, 'notebook.ipynb',
-            )
-
-            if not os.path.isfile(path):
-                print(
-                    f'error: notebook file does not exist at {path}',
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-
-            # Verify the metadata file exists
-            meta_path = os.path.join(
-                args.notebooks_directory,
-                name, 'meta.toml',
-            )
-
-            if not os.path.isfile(meta_path):
-                print(
-                    f'error: metadata file does not exist at {meta_path}',
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-
-            with open(meta_path, 'rb') as meta_toml:
-                nb_meta = tomllib.load(meta_toml)
-
-            try:
-                files.append(
-                    (
-                        path,
-                        f'{i + 1:02} - {nb_meta["meta"]["title"]}.ipynb.json',
-                    ),
-                )
-            except Exception:
-                print(path, ' =>\n    ', nb_meta)
-                raise
+    valid_notebooks = get_valid_notebooks(
+        notebooks=args.notebooks,
+        notebooks_directory=args.notebooks_directory,
+    )
 
     with ZipFile(args.outfile, 'w') as out:
-        for path, name in files:
-            print(path, ' => ', name)
-            contents = read_file(path, strip_outputs=args.strip_outputs)
-            out.writestr(name, contents)
+        for notebook_name in valid_notebooks:
+            print(notebook_name)
+
+            notebook_directory_path = os.path.join(
+                args.notebooks_directory,
+                notebook_name,
+            )
+
+            notebook_path = os.path.join(
+                notebook_directory_path,
+                NOTEBOOK_FILE_NAME
+            )
+
+            # write the whole notebook directory
+            for dirpath, dirs, files in os.walk(notebook_directory_path):
+                for file in files:
+                    source = os.path.join(dirpath, file)
+                    destination = convert_to_destination_path(source)
+
+                    if args.strip_outputs and source == notebook_path:
+                        # don't write notebook here, will be written later after
+                        # transformation
+                        continue
+
+                    out.write(source, arcname=destination)
+
+            if args.strip_outputs:
+                # overwrite notebook file with stripped output version
+                destination = os.path.join(
+                    notebook_name,
+                    NOTEBOOK_FILE_NAME
+                )
+
+                contents = strip_outputs(notebook_path)
+                out.writestr(destination, contents)
+
+

--- a/resources/package-samples.py
+++ b/resources/package-samples.py
@@ -146,12 +146,8 @@ if __name__ == '__main__':
 
             if args.strip_outputs:
                 # write notebook with stripped output
-                destination = os.path.join(
-                    notebook_name,
-                    NOTEBOOK_FILE_NAME,
-                )
+
+                destination = convert_to_destination_path(notebook_path)
 
                 contents = strip_outputs(notebook_path)
                 out.writestr(destination, contents)
-
-


### PR DESCRIPTION
# Summary
- updated the `resources/package-samples.py` script:
  - optionally strip outputs with `--strip-outputs`
  - specify which notebooks it zips with `--notebooks`:
    - `all`
    - `sample` which takes the sample notebooks in `meta.toml`
    - comma-separate list e.g.: `atlas-and-kai,backup-database-s3`
- change the GH action to run on every push to master and provide 3 release files: `sample-notebooks.zip`, `notebooks-stripped.zip`, and `notebooks-full.zip`
- **BREAKING CHANGE**: we now maintain the same folder structure in the zipped files, as we have in the `notebooks` folder in the repo, so the notebook file, all images, metafiles (and any other files) are zipped in their own folder

# Testing
- added some output to a notebook and tested that when `--strip-output` was present the output was removed, and remained when it wasn't
- tested sample notebooks are compiled in new format
- ensured `--notebooks` with each possible value