### PR TITLE
Fix action double-run

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,24 +1,28 @@
 name: pre-commit checks
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.11"
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pre-commit==3.3
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit==3.3
 
-    - name: Analysing the code with pre-commit checks
-      run: |
-        pre-commit run --all-files
+      - name: Analysing the code with pre-commit checks
+        run: |
+          pre-commit run --all-files


### PR DESCRIPTION
- before the precommit checks were being run twice in pull requests because both `push` and `pull_request` were triggering it
- now it runs on push only on the master branch, and the `pull_request` trigger remains the same

## Before

![Screenshot from 2024-05-15 13-32-23](https://github.com/singlestore-labs/spaces-notebooks/assets/4130574/ce7fbf9a-6c9a-4e60-aae7-11a9e87d1b68)

## After

![Screenshot from 2024-05-15 13-32-55](https://github.com/singlestore-labs/spaces-notebooks/assets/4130574/a5e2a6d9-393c-4fe3-b19f-861feab796e3)
