### PR TITLE
Temp: Strip outputs

### DIFF
--- a/resources/nb-check.py
+++ b/resources/nb-check.py
@@ -145,10 +145,13 @@ for f in sys.argv[1:]:
 
     cells = nb.get('cells', [])
 
-    # Remove metadata
+    # Remove metadata and outputs
     for i, cell in enumerate(cells):
         if 'metadata' in cell:
             cell['metadata'] = {}
+        # TODO: do not remove outputs once helios has migrated to published zips
+        if 'outputs' in cell:
+            cell['outputs'] = []
 
     # Remove empty cells at the end of the notebook
     end = len(cells) - 1


### PR DESCRIPTION
While we wait for helios to migrate to the new zip artifacts for the deployment process we should still strip outputs to maintain the same behaviour

Once they have migrated to the zips we can stop stripping them again