### PR TITLE
Trigger bifrost deployments

### DIFF
--- a/.github/workflows/deploy-bifrost.yml
+++ b/.github/workflows/deploy-bifrost.yml
@@ -3,7 +3,7 @@ name: Trigger bifrost deployment
 on:
   push:
     branches:
-      - fs/trigger-bifrost-pipeline
+      - master
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-bifrost.yml
+++ b/.github/workflows/deploy-bifrost.yml
@@ -1,0 +1,21 @@
+name: pre-commit checks
+
+on:
+  push:
+    branches:
+      - fs/trigger-bifrost-pipeline
+
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Trigger bifrost pipeline
+        env:
+          GITLAB_API_TOKEN: ${{ secrets.GITLAB_API_TOKEN }}
+        run: |
+          curl --request POST \
+          --form token=$GITLAB_API_TOKEN \
+          --form ref=master \
+          --form variables[CONTENTSTACK_TRIGGER]="production" \
+          https://gitlab.com/api/v4/projects/33388494/ref/master/trigger/pipeline/

--- a/.github/workflows/deploy-bifrost.yml
+++ b/.github/workflows/deploy-bifrost.yml
@@ -3,7 +3,7 @@ name: Trigger bifrost deployment
 on:
   push:
     branches:
-      - fs/trigger-bifrost-pipeline
+      - master
 
 jobs:
   check:
@@ -17,5 +17,5 @@ jobs:
           curl --request POST \
           --form token=$GITLAB_API_TOKEN \
           --form ref=master \
-          --form variables[CONTENTSTACK_TRIGGER]="production" \
+          --form variables[SPACES_TRIGGER]="production" \
           https://gitlab.com/api/v4/projects/33388494/ref/master/trigger/pipeline/

--- a/.github/workflows/deploy-bifrost.yml
+++ b/.github/workflows/deploy-bifrost.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  check:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-bifrost.yml
+++ b/.github/workflows/deploy-bifrost.yml
@@ -1,4 +1,4 @@
-name: pre-commit checks
+name: Trigger bifrost deployment
 
 on:
   push:
@@ -7,10 +7,10 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Trigger bifrost pipeline
+      - name: Trigger gitlab pipeline
         env:
           GITLAB_API_TOKEN: ${{ secrets.GITLAB_API_TOKEN }}
         run: |

--- a/.github/workflows/deploy-bifrost.yml
+++ b/.github/workflows/deploy-bifrost.yml
@@ -3,7 +3,7 @@ name: Trigger bifrost deployment
 on:
   push:
     branches:
-      - master
+      - fs/trigger-bifrost-pipeline
 
 jobs:
   deploy:


### PR DESCRIPTION
Adds a deploy job that triggers bifrost's deployment on Gitlab CI
Depends on the following bifrost MR: https://gitlab.com/singlestore/engineering/bifrost/-/merge_requests/1715

Have tested by changing the target to this branch temporarily, which triggered this gitlab pipeline: https://gitlab.com/singlestore/engineering/bifrost/-/pipelines/1321187194
Which seems correct, being identical to Contentstack trigger pipelines (except the seo check steps, which are not relevant for this)
