### PR TITLE
fix IP address in the MySQL notebook

### DIFF
--- a/notebooks/unified-data-analysis-sql-nosql-kai/notebook.ipynb
+++ b/notebooks/unified-data-analysis-sql-nosql-kai/notebook.ipynb
@@ -146,7 +146,7 @@
         "%%sql\n",
         "CREATE LINK mysqllink AS MYSQL\n",
         "CONFIG '{\n",
-        "    \"database.hostname\": \"3.141.19.255\",\n",
+        "    \"database.hostname\": \"3.132.226.181\",\n",
         "    \"database.exclude.list\": \"mysql,performance_schema\",\n",
         "    \"table.include.list\": \"DomainAnalytics.transactions\",\n",
         "    \"database.port\": 3306,\n",


### PR DESCRIPTION
This PR fixes the broken IP address in the "Unified Data Analysis: SQL & NoSQL on a Single Database with Kai" notebook with an elastic IP address.