### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/notebooks/building-a-multi-agent-ai-app-with-autogen/notebook.ipynb
+++ b/notebooks/building-a-multi-agent-ai-app-with-autogen/notebook.ipynb
@@ -40,7 +40,7 @@
         "\n",
         "The notebook is divided into several sections:\n",
         "\n",
-        "1. **Installation of Required Libraries**: This section covers the installation of necessary libraries such as `langchain_community`, `pyautogen`, `langchain_openai`, `langchain_text_splitters`, and `unstructured`.\n",
+        "1. **Installation of Required Libraries**: This section covers the installation of necessary libraries such as `langchain_community`, `ag2`, `langchain_openai`, `langchain_text_splitters`, and `unstructured`.\n",
         "\n",
         "2. **Data Loading and Preparation**: This section involves loading a markdown document from a URL and preparing it for further processing.\n",
         "\n",
@@ -78,7 +78,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!pip install --quiet langchain_community pyautogen langchain_openai langchain_text_splitters unstructured"
+        "!pip install --quiet langchain_community ag2 langchain_openai langchain_text_splitters unstructured"
       ],
       "id": "8d379d39"
     },
@@ -154,7 +154,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!pip install --quiet pyautogen[retrievechat]"
+        "!pip install --quiet ag2[retrievechat]"
       ],
       "id": "9042b951"
     },


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
