### PR TITLE
Fix Python UDFs template by removing 'replace_existing' arg

### DIFF
--- a/notebooks/python-udf-template/notebook.ipynb
+++ b/notebooks/python-udf-template/notebook.ipynb
@@ -166,7 +166,7 @@
       "outputs": [],
       "source": [
         "import singlestoredb.apps as apps\n",
-        "connection_info = await apps.run_udf_app(replace_existing=True)"
+        "connection_info = await apps.run_udf_app()"
       ],
       "id": "b716549f"
     },


### PR DESCRIPTION
This PR fixes the Python UDF template by removing `replace_existing=True` from the `apps.run_udf_app(...)` arguments. This parameter has been removed from the definition of `run_udf_app` definition in the Python SDK.