### PR TITLE
Move the Fusion SQL notebooks to the CLUSTER grammar

### DIFF
--- a/notebooks/getting-started-with-fusion-sql/meta.toml
+++ b/notebooks/getting-started-with-fusion-sql/meta.toml
@@ -2,9 +2,8 @@
 authors=["singlestore"]
 title="Getting Started with Fusion SQL"
 description="""\
-    Fusion SQL allows you to manage your SingleStoreDB Cloud
-    resources such as workspace groups, workspaces, and
-    Stage files all from SQL.
+    Fusion SQL allows you to manage your SingleStore Cloud
+    resources such as clusters and Stage files all from SQL.
     """
 icon="browser"
 difficulty="beginner"

--- a/notebooks/getting-started-with-fusion-sql/notebook.ipynb
+++ b/notebooks/getting-started-with-fusion-sql/notebook.ipynb
@@ -22,9 +22,9 @@
       "metadata": {},
       "source": [
         "In this notebook, we introduce Fusion SQL. Fusion SQL are SQL statements that\n",
-        "can be used to manage workspace groups, workspaces, files in workspace stages,\n",
-        "and other resources that could previously only be managed in the portal user\n",
-        "interface or the Management REST API."
+        "can be used to manage clusters, files in cluster Stage, and other resources\n",
+        "that could previously only be managed in the portal user interface or the\n",
+        "Management REST API."
       ],
       "id": "038ad772"
     },
@@ -77,8 +77,8 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Let's try a workflow that goes through the entire process of creating a workspace group, workspace,\n",
-        "and Stage files."
+        "Let's try a workflow that goes through the entire process of creating clusters,\n",
+        "connecting to one, and terminating them."
       ],
       "id": "c9f87f44"
     },
@@ -87,10 +87,17 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Working with workspace groups\n",
+        "## Working with clusters\n",
         "\n",
-        "In this example, we will create a new workspace group, add workspaces, and  demonstrate how to suspend and resume a workspace.\n",
-        "We will then terminate the workspaces and workspace groups all from SQL!"
+        "In this example, we will create two clusters, demonstrate how to suspend and resume one of them,\n",
+        "and then terminate them all from SQL!\n",
+        "\n",
+        "A cluster is a single flat deployment resource: its compute settings and its deployment-wide\n",
+        "settings such as the firewall all live on the one object, and it is named directly by every\n",
+        "command that operates on it.\n",
+        "\n",
+        "Shared-tier deployments have their own set of commands \u2014 `SHOW STARTER CLUSTERS`,\n",
+        "`CREATE STARTER CLUSTER` and `DROP STARTER CLUSTER` \u2014 which are not covered here."
       ],
       "id": "6605910c"
     },
@@ -99,22 +106,32 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Looking above at our list of printed commands, we see that the `CREATE WORKSPACE GROUP`\n",
+        "Looking above at our list of printed commands, we see that the `CREATE CLUSTER`\n",
         "command has the following options:\n",
         "```\n",
-        "CREATE WORKSPACE GROUP [ IF NOT EXISTS ] '<group-name>'\n",
-        "    IN REGION { ID '<region-id>' | '<region-name>' }\n",
-        "    [ WITH PASSWORD '<password>' ]\n",
+        "CREATE CLUSTER [ IF NOT EXISTS ] '<cluster-name>'\n",
+        "    IN REGION '<region-name>'\n",
+        "    [ WITH PROVIDER '<provider>' ]\n",
+        "    [ IN PROJECT { ID '<project-id>' | '<project-name>' } ]\n",
+        "    [ WITH SIZE '<size>' ]\n",
+        "    [ USING SCALE FACTOR <number> ]\n",
+        "    [ WITH FIREWALL RANGES '<ip-range>',... ]\n",
+        "    [ ALLOW ALL TRAFFIC ]\n",
         "    [ EXPIRES AT '<iso-datetime-or-interval>' ]\n",
-        "    [ WITH FIREWALL RANGES '<ip-range>',... ];\n",
+        "    [ WAIT ON ACTIVE ];\n",
         "```\n",
         "\n",
-        "We need a region ID or name to create a workspace group, but luckily there is a Fusion command\n",
-        "that can give us all of the region information. We can use this to get a region from the US\n",
-        "by using the `LIKE` parameter.\n",
+        "We need a region to create a cluster in, and there is a Fusion command that gives us all of\n",
+        "the region information. We can use this to get a region from the US by using the `LIKE`\n",
+        "parameter.\n",
         "```\n",
-        "SHOW REGIONS [ LIKE '<pattern>' ] [ ORDER BY '<key>' [ ASC | DESC ],... ] [ LIMIT <integer> ];\n",
-        "```"
+        "SHOW CLUSTER REGIONS [ LIKE '<pattern>' ] [ ORDER BY '<key>' [ ASC | DESC ],... ] [ LIMIT <integer> ];\n",
+        "```\n",
+        "\n",
+        "Note that there is no region ID and no `IN REGION ID` clause. A region is identified by its\n",
+        "cloud provider and its name. `Name` is the display name, for example `US East 1 (N. Virginia)`,\n",
+        "and `RegionName` is the cloud provider's own name for it, for example `us-east-1`. Either\n",
+        "may be given to `CREATE CLUSTER`."
       ],
       "id": "1a5d9d0f"
     },
@@ -124,7 +141,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "us_regions = %sql SHOW REGIONS LIKE '%US%'\n",
+        "us_regions = %sql SHOW CLUSTER REGIONS LIKE '%US%'\n",
         "us_regions"
       ],
       "id": "4605bd6f"
@@ -134,7 +151,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Let's use the random package to choose a US region for us."
+        "Let's use the random package to choose a US region for us. Since a region name can be\n",
+        "ambiguous across cloud providers, we keep the provider as well and pass both to\n",
+        "`CREATE CLUSTER`."
       ],
       "id": "402b62c5"
     },
@@ -146,8 +165,12 @@
       "source": [
         "import random\n",
         "\n",
-        "region_id = random.choice(us_regions).ID\n",
-        "region_id"
+        "region = random.choice(us_regions)\n",
+        "\n",
+        "region_name = region.Name\n",
+        "provider = region.Provider\n",
+        "\n",
+        "region_name, provider"
       ],
       "id": "989d31f4"
     },
@@ -156,8 +179,14 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Now that we have a region ID, we can create our workspace. We'll open the firewall so it\n",
-        "can be accessed from anywhere and set a password."
+        "Now that we have a region, we can create our clusters. We'll create two of different sizes\n",
+        "and open the firewall so they can be accessed from anywhere.\n",
+        "\n",
+        "Two things to know before running this. A cluster name is restricted to 1-32 characters of\n",
+        "lowercase letters, digits and hyphens, and must start and end with a letter or digit. And the\n",
+        "admin password is generated by the API and reported only at the moment the cluster is created\n",
+        "\u2014 `CREATE CLUSTER` returns it in a row, so we capture that row. A cluster created without\n",
+        "capturing it has no reachable `admin` user."
       ],
       "id": "2cdab621"
     },
@@ -167,10 +196,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "import secrets\n",
-        "\n",
-        "wsg_name = 'Fusion Notebook'\n",
-        "password = secrets.token_urlsafe(20) + '-x&'"
+        "cluster_sizes = {'fusion-cluster-1': 'S-00', 'fusion-cluster-2': 'S-1'}"
       ],
       "id": "0c579720"
     },
@@ -180,9 +206,13 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%sql\n",
-        "CREATE WORKSPACE GROUP '{{ wsg_name }}' IN REGION ID '{{ region_id }}'\n",
-        "       WITH FIREWALL RANGES '0.0.0.0/0' WITH PASSWORD '{{ password }}'"
+        "clusters = {}\n",
+        "\n",
+        "for cluster_name, size in cluster_sizes.items():\n",
+        "    res = %sql CREATE CLUSTER '{{ cluster_name }}' IN REGION '{{ region_name }}' WITH PROVIDER '{{ provider }}' WITH SIZE '{{ size }}' ALLOW ALL TRAFFIC\n",
+        "    clusters[cluster_name] = res[0]\n",
+        "\n",
+        "list(clusters)"
       ],
       "id": "41d5c2d3"
     },
@@ -191,8 +221,8 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "If you are in the SingleStore Cloud portal, you should see the workpace group displayed in a few seconds.\n",
-        "You can also use the `SHOW WORKSPACE GROUPS` command to list them."
+        "If you are in the SingleStore Cloud portal, you should see the clusters displayed in a few\n",
+        "seconds. You can also use the `SHOW CLUSTERS` command to list them."
       ],
       "id": "83d226c5"
     },
@@ -203,7 +233,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW WORKSPACE GROUPS LIKE 'Fusion%'"
+        "SHOW CLUSTERS LIKE 'fusion-cluster-%'"
       ],
       "id": "7624bcdc"
     },
@@ -212,14 +242,16 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### Creating workspaces\n",
+        "### Waiting for the clusters to become active\n",
         "\n",
-        "Now that we have a workspace group, we can create workspaces within it. Let's create\n",
-        "two workspaces of different sizes. Here is the syntax for that operation.\n",
-        "```\n",
-        "CREATE WORKSPACE [ IF NOT EXISTS ] '<workspace-name>' [ IN GROUP { ID '<group-id>' | '<group-name>' } ]\n",
-        "    WITH SIZE '<size>' [ WAIT ON ACTIVE ];\n",
-        "```"
+        "The clusters will take some time to become available. We can write a small wait loop to block\n",
+        "until they are both ready. You could use the `WAIT ON ACTIVE` option for `CREATE CLUSTER`,\n",
+        "but that would cause the two creations to run one after the other. We are using an external\n",
+        "loop so that the two commands above can run in parallel.\n",
+        "\n",
+        "The loop matches on the cluster IDs we captured rather than on the `LIKE` pattern alone.\n",
+        "Terminating a cluster does not remove it from the listing, so a leftover `TERMINATED` cluster\n",
+        "from an earlier run would otherwise keep the loop from ever finishing."
       ],
       "id": "35a7a9e4"
     },
@@ -229,53 +261,24 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%%sql\n",
-        "CREATE WORKSPACE 'workspace-1' IN GROUP '{{ wsg_name }}' WITH SIZE 'S-00';\n",
-        "CREATE WORKSPACE 'workspace-2' IN GROUP '{{ wsg_name }}' WITH SIZE 'S-1';"
-      ],
-      "id": "409c2ac6"
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "The workspaces will take some time to become available. We can write a small wait loop to\n",
-        "block until they are both ready. You could use the `WAIT ON ACTIVE` option for `CREATE WORKSPACE`,\n",
-        "but that would cause them to run sequentially. We are using an external loop so that the\n",
-        "two commands above can run in parallel."
-      ],
-      "id": "2379ad3f"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "def wait_on_attr(cmd: str, **kwargs) -> None:\n",
-        "    \"\"\"Loop until the given attribute of every result row matches.\"\"\"\n",
+        "def wait_on_state(ids, state='ACTIVE') -> None:\n",
+        "    \"\"\"Loop until every cluster in ``ids`` reports the given state.\"\"\"\n",
         "    import time\n",
-        "    import singlestoredb as s2\n",
-        "\n",
-        "    name, value = list(kwargs.items())[0]\n",
         "\n",
         "    n_tries = 20\n",
         "    while n_tries > 0:\n",
-        "        workspaces = %sql {{ cmd }}\n",
-        "        active = [x for x in workspaces if getattr(x, name) == value]\n",
-        "        if len(active) == len(workspaces):\n",
-        "            n_tries = 1\n",
-        "            break\n",
+        "        rows = %sql SHOW CLUSTERS LIKE 'fusion-cluster-%'\n",
+        "        ours = [x for x in rows if x.ID in ids]\n",
+        "        if len(ours) == len(ids) and all(x.State == state for x in ours):\n",
+        "            return\n",
         "        time.sleep(20)\n",
         "        n_tries -= 1\n",
         "\n",
-        "    if n_tries == 0:\n",
-        "        raise RuntimeError('waiting for workspaces timed out')\n",
+        "    raise RuntimeError('waiting for clusters timed out')\n",
         "\n",
         "\n",
-        "# Wait for all workspaces to be active\n",
-        "wait_on_attr(f'SHOW WORKSPACES IN GROUP \"{ wsg_name }\"', State='ACTIVE')"
+        "# Wait for both of our clusters to be active\n",
+        "wait_on_state({x.ID for x in clusters.values()})"
       ],
       "id": "5bf4bd4d"
     },
@@ -284,18 +287,20 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "We can now display the information about the workspaces using the `SHOW WORKSPACES` command."
+        "We can now display the information about the clusters using the `SHOW CLUSTERS` command.\n",
+        "The `EXTENDED` clause adds the endpoint, the cloud provider, the firewall ranges and the\n",
+        "project the cluster belongs to."
       ],
       "id": "f61203be"
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 9,
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW WORKSPACES IN GROUP '{{ wsg_name }}' ORDER BY Name EXTENDED"
+        "SHOW CLUSTERS LIKE 'fusion-cluster-%' ORDER BY Name EXTENDED"
       ],
       "id": "c6da588b"
     },
@@ -304,26 +309,26 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### Suspending and resuming workspaces\n",
+        "### Suspending and resuming clusters\n",
         "\n",
-        "It is possible to suspend and resume workspaces from Fusion SQL as well.\n",
+        "It is possible to suspend and resume clusters from Fusion SQL as well.\n",
         "\n",
         "```\n",
-        "RESUME WORKSPACE { ID '<workspace-id>' | '<workspace-name>' } [ IN GROUP { ID '<group-id>' | '<group-name>' } ] [ WAIT ON RESUMED ];\n",
+        "SUSPEND CLUSTER { ID '<cluster-id>' | '<cluster-name>' } [ WAIT ON SUSPENDED ];\n",
         "\n",
-        "SUSPEND WORKSPACE { ID '<workspace-id>' | '<workspace-name>' } [ IN GROUP { ID '<group-id>' | '<group-name>' } ] [ WAIT ON SUSPENDED ];\n",
+        "RESUME CLUSTER { ID '<cluster-id>' | '<cluster-name>' } [ DISABLE AUTO SUSPEND ] [ WAIT ON RESUMED ];\n",
         "```"
       ],
       "id": "7eabac7b"
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 10,
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SUSPEND WORKSPACE 'workspace-1' IN GROUP '{{ wsg_name }}'"
+        "SUSPEND CLUSTER 'fusion-cluster-1'"
       ],
       "id": "e5e01e3f"
     },
@@ -332,18 +337,18 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "The workspace should have a state of 'SUSPENDED' shortly after running the above command."
+        "The cluster should have a state of 'SUSPENDED' shortly after running the above command."
       ],
       "id": "9c55a846"
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 11,
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW WORKSPACES IN GROUP '{{ wsg_name}}'"
+        "SHOW CLUSTERS LIKE 'fusion-cluster-%'"
       ],
       "id": "92da04c6"
     },
@@ -352,18 +357,18 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "To resume the workspace, you use the `RESUME WORKSPACE` command."
+        "To resume the cluster, you use the `RESUME CLUSTER` command."
       ],
       "id": "887fc459"
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 12,
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "RESUME WORKSPACE 'workspace-1' IN GROUP '{{ wsg_name }}' WAIT ON RESUMED"
+        "RESUME CLUSTER 'fusion-cluster-1' WAIT ON RESUMED"
       ],
       "id": "bf33363a"
     },
@@ -371,18 +376,18 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Display the information about the workspaces again."
+        "Display the information about the clusters again."
       ],
       "id": "c4a1e2ac"
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 13,
       "metadata": {},
       "outputs": [],
       "source": [
-        "workspaces = %sql SHOW WORKSPACES IN GROUP '{{ wsg_name}}' EXTENDED\n",
-        "workspaces"
+        "cluster_info = %sql SHOW CLUSTERS LIKE 'fusion-cluster-%' EXTENDED\n",
+        "cluster_info"
       ],
       "id": "67d2c61f"
     },
@@ -391,22 +396,26 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### Accessing the database endpoint of a workspace\n",
+        "### Accessing the database endpoint of a cluster\n",
         "\n",
-        "As you saw above, we have access to the database endpoint in the workspace information.\n",
-        "We can use that to create a connection to that workspace for database operations."
+        "As you saw above, we have access to the database endpoint in the cluster information.\n",
+        "Together with the admin password that `CREATE CLUSTER` reported, we can use that to create\n",
+        "a connection to the cluster for database operations."
       ],
       "id": "290165aa"
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 14,
       "metadata": {},
       "outputs": [],
       "source": [
         "import singlestoredb as s2\n",
         "\n",
-        "with s2.connect(f'admin:{ password }@{ workspaces[0].Endpoint }:3306') as conn:\n",
+        "endpoint = {x.Name: x.Endpoint for x in cluster_info}['fusion-cluster-1']\n",
+        "password = clusters['fusion-cluster-1'].AdminPassword\n",
+        "\n",
+        "with s2.connect(f'admin:{ password }@{ endpoint }:3306') as conn:\n",
         "    with conn.cursor() as cur:\n",
         "        cur.execute('show databases')\n",
         "        for row in cur:\n",
@@ -419,14 +428,16 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### Terminating workspaces and workspace groups\n",
+        "### Terminating clusters\n",
         "\n",
-        "You can terminate workspaces and workspace groups from Fusion SQL commands as well.\n",
+        "You can terminate clusters from Fusion SQL commands as well.\n",
         "```\n",
-        "DROP WORKSPACE [ IF EXISTS ] { ID '<workspace-id>' | '<workspace-name>' } [ IN GROUP { ID '<group-id>' | '<group-name>' } ] [ WAIT ON TERMINATED ];\n",
+        "DROP CLUSTER [ IF EXISTS ] { ID '<cluster-id>' | '<cluster-name>' } [ WAIT ON TERMINATED ];\n",
+        "```\n",
         "\n",
-        "DROP WORKSPACE GROUP [ IF EXISTS ] { ID '<group-id>' | '<group-name>' } [ WAIT ON TERMINATED ] [ FORCE ];\n",
-        "```"
+        "Dropping the cluster is the whole of the cleanup: there is nothing left over to remove\n",
+        "afterwards, and so no `FORCE` option. All databases attached to the cluster are detached\n",
+        "when the cluster is deleted."
       ],
       "id": "66622efe"
     },
@@ -435,18 +446,18 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Let's drop `workspace-2` and leave `workspace-1` in place."
+        "Let's drop `fusion-cluster-2` and leave `fusion-cluster-1` in place."
       ],
       "id": "637694a7"
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 15,
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "DROP WORKSPACE 'workspace-2' IN GROUP '{{ wsg_name }}'"
+        "DROP CLUSTER 'fusion-cluster-2'"
       ],
       "id": "fcd1e469"
     },
@@ -455,19 +466,20 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "The above operation may take a few seconds. Once it has completed, the following output will\n",
-        "show just one workspace remaining."
+        "The above operation may take a few seconds. Once it has completed, `fusion-cluster-2` will\n",
+        "report a state of `TERMINATED`. Note that a terminated cluster is not removed from the\n",
+        "listing, so it keeps showing up in `SHOW CLUSTERS` with that state."
       ],
       "id": "19a1db5f"
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 16,
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW WORKSPACES IN GROUP '{{ wsg_name }}'"
+        "SHOW CLUSTERS LIKE 'fusion-cluster-%'"
       ],
       "id": "f60b8887"
     },
@@ -476,11 +488,21 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "It is possible to terminate a workspace group even if it has workspaces in it\n",
-        "by using the `FORCE` option. Let's remove our workspace group with `workspace-1`\n",
-        "still in it."
+        "Now let's remove the remaining cluster, this time waiting for the termination to finish\n",
+        "before continuing."
       ],
       "id": "b4f79288"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%%sql\n",
+        "DROP CLUSTER 'fusion-cluster-1' WAIT ON TERMINATED"
+      ],
+      "id": "2c710871"
     },
     {
       "cell_type": "code",
@@ -489,18 +511,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "DROP WORKSPACE GROUP '{{ wsg_name }}' FORCE"
-      ],
-      "id": "2c710871"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%%sql\n",
-        "SHOW WORKSPACE GROUPS LIKE 'Fusion%'"
+        "SHOW CLUSTERS LIKE 'fusion-cluster-%'"
       ],
       "id": "41c2a6df"
     },
@@ -509,21 +520,23 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "We can attempt to list the workspaces in the group again, but this time\n",
-        "you will get a KeyError saying that the workspace group is not found."
+        "Naming a cluster that does not exist raises a `KeyError`. Add the `IF EXISTS` clause when\n",
+        "you would rather the command do nothing."
       ],
       "id": "05aa3068"
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 19,
       "metadata": {},
       "outputs": [],
       "source": [
         "try:\n",
-        "    %sql SHOW WORKSPACES IN GROUP '{{ wsg_name }}'\n",
+        "    %sql DROP CLUSTER 'no-such-cluster'\n",
         "except KeyError:\n",
-        "    print('no workspace group was found')"
+        "    print('no cluster was found')\n",
+        "\n",
+        "%sql DROP CLUSTER IF EXISTS 'no-such-cluster'"
       ],
       "id": "13b54a15"
     },
@@ -534,10 +547,10 @@
       "source": [
         "## Conclusion\n",
         "\n",
-        "We have covered the Fusion SQL commands for creating and terminating both workspace groups\n",
-        "and workspaces. We also demonstrated how to suspend and resume workspaces. Fusion SQL\n",
-        "can also manage your Stage files. That topic is covered in another example notebook,\n",
-        "and more Fusion SQL commands will be added as features are added to SingleStoreDB Cloud."
+        "We have covered the Fusion SQL commands for creating and terminating clusters, and we\n",
+        "demonstrated how to suspend and resume one. Fusion SQL can also manage your Stage files.\n",
+        "That topic is covered in another example notebook, and more Fusion SQL commands will be\n",
+        "added as features are added to SingleStore Cloud."
       ],
       "id": "a45b4c7a"
     },

--- a/notebooks/getting-started-with-fusion-sql/notebook.ipynb
+++ b/notebooks/getting-started-with-fusion-sql/notebook.ipynb
@@ -111,7 +111,7 @@
         "```\n",
         "CREATE CLUSTER [ IF NOT EXISTS ] '<cluster-name>'\n",
         "    IN REGION '<region-name>'\n",
-        "    [ WITH PROVIDER '<provider>' ]\n",
+        "    [ USING PROVIDER '<provider>' ]\n",
         "    [ IN PROJECT { ID '<project-id>' | '<project-name>' } ]\n",
         "    [ WITH SIZE '<size>' ]\n",
         "    [ USING SCALE FACTOR <number> ]\n",
@@ -179,8 +179,12 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Now that we have a region, we can create our clusters. We'll create two of different sizes\n",
-        "and open the firewall so they can be accessed from anywhere.\n",
+        "### Creating clusters\n",
+        "\n",
+        "Now that we have a region, we can create our clusters. Let's create two of different sizes\n",
+        "and open the firewall so they can be accessed from anywhere. Both the size and the firewall\n",
+        "are clauses of `CREATE CLUSTER` itself, along with the scale factor, the expiration and the\n",
+        "project, as shown in the syntax above.\n",
         "\n",
         "Two things to know before running this. A cluster name is restricted to 1-32 characters of\n",
         "lowercase letters, digits and hyphens, and must start and end with a letter or digit. And the\n",
@@ -196,23 +200,12 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "cluster_sizes = {'fusion-cluster-1': 'S-00', 'fusion-cluster-2': 'S-1'}"
-      ],
-      "id": "0c579720"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "clusters = {}\n",
+        "res_1 = %sql CREATE CLUSTER 'fusion-cluster-1' IN REGION '{{ region_name }}' USING PROVIDER '{{ provider }}' WITH SIZE 'S-00' ALLOW ALL TRAFFIC\n",
+        "res_2 = %sql CREATE CLUSTER 'fusion-cluster-2' IN REGION '{{ region_name }}' USING PROVIDER '{{ provider }}' WITH SIZE 'S-1' ALLOW ALL TRAFFIC\n",
         "\n",
-        "for cluster_name, size in cluster_sizes.items():\n",
-        "    res = %sql CREATE CLUSTER '{{ cluster_name }}' IN REGION '{{ region_name }}' WITH PROVIDER '{{ provider }}' WITH SIZE '{{ size }}' ALLOW ALL TRAFFIC\n",
-        "    clusters[cluster_name] = res[0]\n",
+        "cluster_1, cluster_2 = res_1[0], res_2[0]\n",
         "\n",
-        "list(clusters)"
+        "cluster_1.Name, cluster_2.Name"
       ],
       "id": "41d5c2d3"
     },
@@ -228,7 +221,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 6,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -257,7 +250,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 7,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -278,7 +271,7 @@
         "\n",
         "\n",
         "# Wait for both of our clusters to be active\n",
-        "wait_on_state({x.ID for x in clusters.values()})"
+        "wait_on_state({cluster_1.ID, cluster_2.ID})"
       ],
       "id": "5bf4bd4d"
     },
@@ -295,7 +288,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 8,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -323,7 +316,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 9,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -343,7 +336,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 10,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -363,7 +356,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 11,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -382,7 +375,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 12,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -406,14 +399,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 13,
       "metadata": {},
       "outputs": [],
       "source": [
         "import singlestoredb as s2\n",
         "\n",
         "endpoint = {x.Name: x.Endpoint for x in cluster_info}['fusion-cluster-1']\n",
-        "password = clusters['fusion-cluster-1'].AdminPassword\n",
+        "password = cluster_1.AdminPassword\n",
         "\n",
         "with s2.connect(f'admin:{ password }@{ endpoint }:3306') as conn:\n",
         "    with conn.cursor() as cur:\n",
@@ -452,7 +445,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 14,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -474,7 +467,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 15,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -495,7 +488,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 16,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -506,7 +499,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 17,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -527,7 +520,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": 18,
       "metadata": {},
       "outputs": [],
       "source": [

--- a/notebooks/getting-started-with-fusion-sql/notebook.ipynb
+++ b/notebooks/getting-started-with-fusion-sql/notebook.ipynb
@@ -392,7 +392,13 @@
         "\n",
         "As you saw above, we have access to the database endpoint in the cluster information.\n",
         "Together with the admin password that `CREATE CLUSTER` reported, we can use that to create\n",
-        "a connection to the cluster for database operations."
+        "a connection to the cluster for database operations.\n",
+        "\n",
+        "The connection parameters are passed as keyword arguments rather than interpolated into a\n",
+        "connection string. The generated admin password is not URL-safe \u2014 it can contain `?`, `/`,\n",
+        "`@`, `#`, `:` and `%` \u2014 and any of those change how a URL is read: a `?` starts the query\n",
+        "string, so everything after it drops out of the host, and a `%` starts an escape sequence.\n",
+        "Keyword arguments are taken literally, so the password arrives as issued."
       ],
       "id": "290165aa"
     },
@@ -407,7 +413,9 @@
         "endpoint = {x.Name: x.Endpoint for x in cluster_info}['fusion-cluster-1']\n",
         "password = cluster_1.AdminPassword\n",
         "\n",
-        "with s2.connect(f'admin:{ password }@{ endpoint }:3306') as conn:\n",
+        "with s2.connect(\n",
+        "    host=endpoint, port=3306, user='admin', password=password,\n",
+        ") as conn:\n",
         "    with conn.cursor() as cur:\n",
         "        cur.execute('show databases')\n",
         "        for row in cur:\n",

--- a/notebooks/getting-started-with-fusion-sql/notebook.ipynb
+++ b/notebooks/getting-started-with-fusion-sql/notebook.ipynb
@@ -92,9 +92,8 @@
         "In this example, we will create two clusters, demonstrate how to suspend and resume one of them,\n",
         "and then terminate them all from SQL!\n",
         "\n",
-        "A cluster is a single flat deployment resource: its compute settings and its deployment-wide\n",
-        "settings such as the firewall all live on the one object, and it is named directly by every\n",
-        "command that operates on it.\n",
+        "A cluster carries both its compute settings and its deployment-wide settings, such as the\n",
+        "firewall, on the one object, and every command that operates on a cluster names it directly.\n",
         "\n",
         "Shared-tier deployments have their own set of commands \u2014 `SHOW STARTER CLUSTERS`,\n",
         "`CREATE STARTER CLUSTER` and `DROP STARTER CLUSTER` \u2014 which are not covered here."
@@ -128,10 +127,10 @@
         "SHOW CLUSTER REGIONS [ LIKE '<pattern>' ] [ ORDER BY '<key>' [ ASC | DESC ],... ] [ LIMIT <integer> ];\n",
         "```\n",
         "\n",
-        "Note that there is no region ID and no `IN REGION ID` clause. A region is identified by its\n",
-        "cloud provider and its name. `Name` is the display name, for example `US East 1 (N. Virginia)`,\n",
-        "and `RegionName` is the cloud provider's own name for it, for example `us-east-1`. Either\n",
-        "may be given to `CREATE CLUSTER`."
+        "A region is identified by its cloud provider and its name. `Name` is the display name, for\n",
+        "example `US East 1 (N. Virginia)`, and `RegionName` is the cloud provider's own name for it,\n",
+        "for example `us-east-1`. Either may be given to `IN REGION`, and `USING PROVIDER` picks\n",
+        "between providers that offer a region under the same name."
       ],
       "id": "1a5d9d0f"
     },
@@ -182,9 +181,9 @@
         "### Creating clusters\n",
         "\n",
         "Now that we have a region, we can create our clusters. Let's create two of different sizes\n",
-        "and open the firewall so they can be accessed from anywhere. Both the size and the firewall\n",
-        "are clauses of `CREATE CLUSTER` itself, along with the scale factor, the expiration and the\n",
-        "project, as shown in the syntax above.\n",
+        "and open the firewall so they can be accessed from anywhere. The size and the firewall are\n",
+        "both clauses of `CREATE CLUSTER`, along with the scale factor, the expiration and the project,\n",
+        "as shown in the syntax above.\n",
         "\n",
         "Two things to know before running this. A cluster name is restricted to 1-32 characters of\n",
         "lowercase letters, digits and hyphens, and must start and end with a letter or digit. And the\n",
@@ -428,9 +427,8 @@
         "DROP CLUSTER [ IF EXISTS ] { ID '<cluster-id>' | '<cluster-name>' } [ WAIT ON TERMINATED ];\n",
         "```\n",
         "\n",
-        "Dropping the cluster is the whole of the cleanup: there is nothing left over to remove\n",
-        "afterwards, and so no `FORCE` option. All databases attached to the cluster are detached\n",
-        "when the cluster is deleted."
+        "Dropping the cluster is the whole of the cleanup. All databases attached to the cluster are\n",
+        "detached when it is deleted, and nothing is left behind to remove afterwards."
       ],
       "id": "66622efe"
     },

--- a/notebooks/managing-stage-files-with-fusion-sql/notebook.ipynb
+++ b/notebooks/managing-stage-files-with-fusion-sql/notebook.ipynb
@@ -22,10 +22,9 @@
       "id": "c33d5542",
       "metadata": {},
       "source": [
-        "Fusion SQL can be used to manage your workspace groups and workspaces, but it\n",
-        "can also be used to upload, download, and manage files in your workspace group\n",
-        "or starter workspace Stage. We'll show you how to work with files in Stage in\n",
-        "this notebook."
+        "Fusion SQL can be used to manage your clusters, but it can also be used to\n",
+        "upload, download, and manage files in your cluster or starter cluster Stage.\n",
+        "We'll show you how to work with files in Stage in this notebook."
       ]
     },
     {
@@ -58,10 +57,12 @@
       "id": "91485576",
       "metadata": {},
       "source": [
-        "## Creating a workspace group\n",
+        "## Creating a cluster\n",
         "\n",
-        "We'll start by creating a workspace group. We can get a region in the US by using the `SHOW REGIONS`\n",
-        "command and the `random` package."
+        "We'll start by creating a cluster, whose Stage we will work with for the rest of the notebook.\n",
+        "We can get a region in the US by using the `SHOW CLUSTER REGIONS` command and the `random`\n",
+        "package. Regions have no IDs \u2014 a region is identified by its name and cloud provider \u2014 so we\n",
+        "keep both and pass both to `CREATE CLUSTER`."
       ]
     },
     {
@@ -72,12 +73,15 @@
       "outputs": [],
       "source": [
         "import random\n",
-        "import secrets\n",
         "\n",
-        "us_regions = %sql SHOW REGIONS LIKE '%us%'\n",
+        "us_regions = %sql SHOW CLUSTER REGIONS LIKE '%us%'\n",
         "\n",
-        "region_id = random.choice(us_regions).ID\n",
-        "region_id"
+        "region = random.choice(us_regions)\n",
+        "\n",
+        "region_name = region.Name\n",
+        "provider = region.Provider\n",
+        "\n",
+        "region_name, provider"
       ]
     },
     {
@@ -87,8 +91,9 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "wg_name = 'Fusion Notebook'\n",
-        "password = secrets.token_urlsafe(20) + '-x&'"
+        "# Cluster names are limited to 1-32 characters of lowercase letters, digits\n",
+        "# and hyphens, and must start and end with a letter or digit.\n",
+        "cluster_name = 'fusion-notebook'"
       ]
     },
     {
@@ -99,9 +104,9 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "CREATE WORKSPACE GROUP '{{ wg_name }}'\n",
-        "    IN REGION ID '{{ region_id }}' WITH PASSWORD '{{ password }}'\n",
-        "    WITH FIREWALL RANGES '0.0.0.0/0'"
+        "CREATE CLUSTER '{{ cluster_name }}'\n",
+        "    IN REGION '{{ region_name }}' WITH PROVIDER '{{ provider }}'\n",
+        "    WITH SIZE 'S-00' ALLOW ALL TRAFFIC WAIT ON ACTIVE"
       ]
     },
     {
@@ -110,6 +115,10 @@
       "id": "0567f05d",
       "metadata": {},
       "source": [
+        "The row returned above includes the admin password for the new cluster. The API generates it\n",
+        "and reports it only at creation time, so if you intend to connect to the cluster as `admin`\n",
+        "later on, keep it.\n",
+        "\n",
         "## Uploading and downloading Stage files\n",
         "\n",
         "Uploading and downloading files to your Stage is easy with Fusion SQL. The commands are shown below.\n",
@@ -119,6 +128,9 @@
         "\n",
         "UPLOAD FILE TO STAGE '<stage-path>' [ IN { ID '<deployment-id>' | '<deployment-name>' } ] FROM '<local-path>' [ OVERWRITE ];\n",
         "```\n",
+        "\n",
+        "The `IN` clause names a deployment, which is either a cluster or a starter cluster. Left off,\n",
+        "the commands work on the Stage of the deployment the notebook is attached to.\n",
         "\n",
         "First we'll create a data file locally that we can work with."
       ]
@@ -144,7 +156,7 @@
       "id": "b333c9e8",
       "metadata": {},
       "source": [
-        "We can now upload our data file to our workspace group Stage."
+        "We can now upload our data file to our cluster Stage."
       ]
     },
     {
@@ -155,7 +167,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "UPLOAD FILE TO STAGE 'stats.csv' IN '{{ wg_name }}' FROM 'mydata.csv'"
+        "UPLOAD FILE TO STAGE 'stats.csv' IN '{{ cluster_name }}' FROM 'mydata.csv'"
       ]
     },
     {
@@ -175,7 +187,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW STAGE FILES IN '{{ wg_name }}'"
+        "SHOW STAGE FILES IN '{{ cluster_name }}'"
       ]
     },
     {
@@ -195,7 +207,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "DOWNLOAD STAGE FILE 'stats.csv' IN '{{ wg_name }}' TO 'stats.csv' OVERWRITE"
+        "DOWNLOAD STAGE FILE 'stats.csv' IN '{{ cluster_name }}' TO 'stats.csv' OVERWRITE"
       ]
     },
     {
@@ -226,7 +238,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "DOWNLOAD STAGE FILE 'stats.csv' IN '{{ wg_name }}' ENCODING 'utf-8'"
+        "DOWNLOAD STAGE FILE 'stats.csv' IN '{{ cluster_name }}' ENCODING 'utf-8'"
       ]
     },
     {
@@ -260,7 +272,7 @@
       "outputs": [],
       "source": [
         "for name in ['project-1', 'project-1/data', 'project-2', 'project-2/data']:\n",
-        "    %sql CREATE STAGE FOLDER '{{ name }}' IN '{{ wg_name }}';"
+        "    %sql CREATE STAGE FOLDER '{{ name }}' IN '{{ cluster_name }}';"
       ]
     },
     {
@@ -271,7 +283,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW STAGE FILES IN '{{ wg_name }}' RECURSIVE"
+        "SHOW STAGE FILES IN '{{ cluster_name }}' RECURSIVE"
       ]
     },
     {
@@ -291,8 +303,8 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "UPLOAD FILE TO STAGE 'project-1/data/stats.csv' IN '{{ wg_name }}' FROM 'mydata.csv';\n",
-        "UPLOAD FILE TO STAGE 'project-2/data/stats.csv' IN '{{ wg_name }}' FROM 'mydata.csv';"
+        "UPLOAD FILE TO STAGE 'project-1/data/stats.csv' IN '{{ cluster_name }}' FROM 'mydata.csv';\n",
+        "UPLOAD FILE TO STAGE 'project-2/data/stats.csv' IN '{{ cluster_name }}' FROM 'mydata.csv';"
       ]
     },
     {
@@ -312,7 +324,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW STAGE FILES IN '{{ wg_name }}' RECURSIVE"
+        "SHOW STAGE FILES IN '{{ cluster_name }}' RECURSIVE"
       ]
     },
     {
@@ -332,7 +344,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW STAGE FILES IN '{{ wg_name }}' AT 'project-2/data'"
+        "SHOW STAGE FILES IN '{{ cluster_name }}' AT 'project-2/data'"
       ]
     },
     {
@@ -343,30 +355,20 @@
       "source": [
         "## Loading data from Stage\n",
         "\n",
-        "We are going to load data from a Stage into a database table. For this, we need to\n",
-        "have a workspace and a database."
+        "We are going to load data from a Stage into a database table. A cluster is both the Stage and\n",
+        "the compute that reads from it, so all we need now is a database on the cluster we created\n",
+        "above."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": 16,
-      "id": "b3c4e207",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%%sql\n",
-        "CREATE WORKSPACE 'stage-loader' IN GROUP '{{ wg_name }}' WITH SIZE 'S-00' WAIT ON ACTIVE"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
       "id": "36d0e56b",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW WORKSPACES IN GROUP 'Fusion Notebook'"
+        "SHOW CLUSTERS LIKE '{{ cluster_name }}'"
       ]
     },
     {
@@ -379,14 +381,14 @@
         "    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n",
         "    <div>\n",
         "        <p><b>Action Required</b></p>\n",
-        "        <p>Make sure to select the <tt>stage-loader</tt> workspace from the drop-down menu at the top of this notebook.</p>\n",
+        "        <p>Make sure to select the <tt>fusion-notebook</tt> cluster from the drop-down menu at the top of this notebook.</p>\n",
         "    </div>\n",
         "</div>"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 17,
       "id": "c97e381f",
       "metadata": {},
       "outputs": [],
@@ -413,7 +415,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": 18,
       "id": "28c4dab8",
       "metadata": {},
       "outputs": [],
@@ -438,7 +440,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 19,
       "id": "cbef048d",
       "metadata": {},
       "outputs": [],
@@ -471,7 +473,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 20,
       "id": "e04ea9c9",
       "metadata": {},
       "outputs": [],
@@ -484,18 +486,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": 21,
       "id": "4cf83faf",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW STAGE FILES IN '{{ wg_name }}' AT 'project-3' RECURSIVE"
+        "SHOW STAGE FILES IN '{{ cluster_name }}' AT 'project-3' RECURSIVE"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
+      "execution_count": 22,
       "id": "b41add98",
       "metadata": {},
       "outputs": [],
@@ -512,7 +514,7 @@
       "source": [
         "## Deleting Stage files and folders\n",
         "\n",
-        "Files and folders can be deleted from a workspace Stage as well.\n",
+        "Files and folders can be deleted from a cluster Stage as well.\n",
         "This is done with the `DROP STAGE FILE` and `DROP STAGE FOLDER` commands.\n",
         "```\n",
         "DROP STAGE FILE '<stage-path>' [ IN { ID '<deployment-id>' | '<deployment-name>' } ];\n",
@@ -525,24 +527,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
+      "execution_count": 23,
       "id": "058ab079",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "DROP STAGE FILE 'stats.csv' IN '{{ wg_name }}'"
+        "DROP STAGE FILE 'stats.csv' IN '{{ cluster_name }}'"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
+      "execution_count": 24,
       "id": "96516b35",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW STAGE FILES IN '{{ wg_name }}'"
+        "SHOW STAGE FILES IN '{{ cluster_name }}'"
       ]
     },
     {
@@ -556,36 +558,36 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 26,
+      "execution_count": 25,
       "id": "112632ed",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "DROP STAGE FOLDER 'project-2' IN '{{ wg_name }}' RECURSIVE"
+        "DROP STAGE FOLDER 'project-2' IN '{{ cluster_name }}' RECURSIVE"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": 26,
       "id": "58410c8c",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SHOW STAGE FILES IN '{{ wg_name }}' RECURSIVE"
+        "SHOW STAGE FILES IN '{{ cluster_name }}' RECURSIVE"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 28,
+      "execution_count": 27,
       "id": "0c1291e3",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
-        "DROP STAGE FOLDER 'project-1' IN '{{ wg_name }}' RECURSIVE;\n",
-        "DROP STAGE FOLDER 'project-3' IN '{{ wg_name }}' RECURSIVE;"
+        "DROP STAGE FOLDER 'project-1' IN '{{ cluster_name }}' RECURSIVE;\n",
+        "DROP STAGE FOLDER 'project-3' IN '{{ cluster_name }}' RECURSIVE;"
       ]
     },
     {
@@ -596,11 +598,14 @@
       "source": [
         "## Conclusion\n",
         "\n",
-        "We have demonstrated how to create and delete files and folders in a workspace group Stage\n",
-        "using Fusion SQL. Note that it also supports managing Stage for starter workspaces. It is\n",
+        "We have demonstrated how to create and delete files and folders in a cluster Stage\n",
+        "using Fusion SQL. Note that it also supports managing Stage for starter clusters. It is\n",
         "also possible to work with Stage files using the SingleStoreDB Python SDK, see the\n",
         "[API documentation](https://singlestoredb-python.labs.singlestore.com/api.html#stage)\n",
-        "for more details."
+        "for more details.\n",
+        "\n",
+        "The cluster we created is still running. Use `DROP CLUSTER 'fusion-notebook'` to\n",
+        "terminate it when you are done."
       ]
     },
     {

--- a/notebooks/managing-stage-files-with-fusion-sql/notebook.ipynb
+++ b/notebooks/managing-stage-files-with-fusion-sql/notebook.ipynb
@@ -61,8 +61,8 @@
         "\n",
         "We'll start by creating a cluster, whose Stage we will work with for the rest of the notebook.\n",
         "We can get a region in the US by using the `SHOW CLUSTER REGIONS` command and the `random`\n",
-        "package. Regions have no IDs \u2014 a region is identified by its name and cloud provider \u2014 so we\n",
-        "keep both and pass both to `CREATE CLUSTER`."
+        "package. A region is identified by its name and cloud provider, so we keep both and pass them\n",
+        "to `IN REGION` and `USING PROVIDER`."
       ]
     },
     {

--- a/notebooks/managing-stage-files-with-fusion-sql/notebook.ipynb
+++ b/notebooks/managing-stage-files-with-fusion-sql/notebook.ipynb
@@ -591,6 +591,30 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "id": "b5f41b37",
+      "source": [
+        "## Cleanup\n",
+        "\n",
+        "Finally, terminate the cluster we created at the start of the notebook. This is the last\n",
+        "step for a reason: the notebook session is attached to that cluster, so its database\n",
+        "connection goes away with it. The `DROP CLUSTER` command itself is unaffected \u2014 Fusion SQL\n",
+        "sends it to the management API rather than to the cluster."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "id": "9df16d32",
+      "source": [
+        "%%sql\n",
+        "DROP CLUSTER '{{ cluster_name }}' WAIT ON TERMINATED"
+      ],
+      "metadata": {},
+      "execution_count": 28,
+      "outputs": []
+    },
+    {
       "attachments": {},
       "cell_type": "markdown",
       "id": "9708218d",
@@ -602,10 +626,7 @@
         "using Fusion SQL. Note that it also supports managing Stage for starter clusters. It is\n",
         "also possible to work with Stage files using the SingleStoreDB Python SDK, see the\n",
         "[API documentation](https://singlestoredb-python.labs.singlestore.com/api.html#stage)\n",
-        "for more details.\n",
-        "\n",
-        "The cluster we created is still running. Use `DROP CLUSTER 'fusion-notebook'` to\n",
-        "terminate it when you are done."
+        "for more details."
       ]
     },
     {

--- a/notebooks/managing-stage-files-with-fusion-sql/notebook.ipynb
+++ b/notebooks/managing-stage-files-with-fusion-sql/notebook.ipynb
@@ -105,7 +105,7 @@
       "source": [
         "%%sql\n",
         "CREATE CLUSTER '{{ cluster_name }}'\n",
-        "    IN REGION '{{ region_name }}' WITH PROVIDER '{{ provider }}'\n",
+        "    IN REGION '{{ region_name }}' USING PROVIDER '{{ provider }}'\n",
         "    WITH SIZE 'S-00' ALLOW ALL TRAFFIC WAIT ON ACTIVE"
       ]
     },


### PR DESCRIPTION
The `WORKSPACE GROUP` / `WORKSPACE` Fusion SQL commands are deprecated in favour of the flat `CLUSTER` commands backed by management API v2. The two notebooks that taught the old grammar now teach the new one.

## Getting Started with Fusion SQL

Drops the group-then-workspace sequence for two clusters created directly, and picks up what follows from the flatter resource:

- `SHOW CLUSTER REGIONS` replaces `SHOW REGIONS`. Regions have no IDs, so there is no `IN REGION ID` clause — a region is named by its display name or provider name, with `WITH PROVIDER` to disambiguate.
- There is no `WITH PASSWORD` clause. The API generates the admin password and reports it only in the row `CREATE CLUSTER` returns, so the notebook captures that row and uses it for the endpoint connection.
- Cluster names are restricted to 1-32 characters of lowercase letters, digits and hyphens, so `Fusion Notebook` becomes `fusion-cluster-1` / `fusion-cluster-2`.
- `DROP CLUSTER` is the whole of the teardown — no `FORCE`, and nothing left behind to remove.
- The wait loop now matches on the cluster IDs it captured. A terminated cluster stays in the `SHOW CLUSTERS` listing, so a leftover from an earlier run would otherwise hold the loop open forever. The narrative says this explicitly where the drops happen.
- The closing `KeyError` demonstration moves to `DROP CLUSTER`, which still raises one for an unknown name unless `IF EXISTS` is given.

## Managing Stage files with Fusion SQL

Creates one cluster and names it with the bare `IN` clause the Stage commands take. The `CREATE WORKSPACE 'stage-loader'` step is gone entirely: the cluster is both the Stage and the compute that loads from it, so there is nothing left to create inside it.

The second commit fixes a pre-existing leak while it is in the area. The notebook has always left its deployment running -- it created a workspace group and a workspace and dropped neither -- so it now ends with a `DROP CLUSTER`. That goes last because the notebook session is attached to the cluster and loses its database connection with it; the command itself still lands, since Fusion SQL sends it to the management API rather than down the connection it is terminating.

## Not changed

`Running Notebooks from Another Notebook with Fusion SQL` only uses the `SHARED FILE` and `JOB` commands, which are unaffected.

Several other notebooks mention "workspace group" in prose only, with no Fusion SQL involved. Those are left for a separate pass.

## Testing

Every Fusion statement in all three notebooks was extracted and parsed against the SDK's Fusion grammar (`singlestoredb.fusion`) with the templated variables filled in: 46 statements, 0 failures, the 7 skips being ordinary SQL (`CREATE DATABASE`, the pipeline, the `SELECT ... INTO STAGE`). No live provisioning was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-notebook edits only; no application or API runtime code changes.
> 
> **Overview**
> Updates the **Getting Started with Fusion SQL** and **Managing Stage files with Fusion SQL** notebooks (and the getting-started `meta.toml` blurb) so they teach the flat **`CLUSTER`** Fusion SQL commands instead of deprecated **`WORKSPACE GROUP`** / **`WORKSPACE`** flows aligned with management API v2.
> 
> The getting-started walkthrough now provisions **two clusters directly** (`SHOW CLUSTER REGIONS`, `CREATE CLUSTER`, `SHOW CLUSTERS`, suspend/resume, connect via API-returned **admin password** with keyword `s2.connect`, `DROP CLUSTER`), drops group/workspace nesting and `WITH PASSWORD`, and hardens the **wait loop** to match captured cluster IDs so leftover **TERMINATED** rows do not block completion.
> 
> The Stage notebook switches Stage targets to a single **`fusion-notebook`** cluster, removes the extra **`CREATE WORKSPACE`** loader step (cluster is both Stage and compute), and adds a final **`DROP CLUSTER`** cleanup that was previously missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58bfa5479ccaad799d600a8c17ff32cfde9e951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->