### PR TITLE
refact: user inputs now properly render for data

### DIFF
--- a/notebooks/movie-recommendation/notebook.ipynb
+++ b/notebooks/movie-recommendation/notebook.ipynb
@@ -18,7 +18,6 @@
     },
     {
       "cell_type": "markdown",
-      "id": "bd3c1a79",
       "metadata": {},
       "source": [
         "<div class=\"alert alert-block alert-info\">\n",
@@ -54,7 +53,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "id": "039f0b97",
       "metadata": {},
       "outputs": [],
@@ -80,7 +79,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "id": "3e763118",
       "metadata": {},
       "outputs": [],
@@ -115,7 +114,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "id": "3e21f911",
       "metadata": {},
       "outputs": [],
@@ -156,7 +155,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "id": "fe23f570",
       "metadata": {},
       "outputs": [],
@@ -197,7 +196,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "id": "f7e76f0f",
       "metadata": {},
       "outputs": [],
@@ -241,7 +240,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "id": "9b7d1d50",
       "metadata": {},
       "outputs": [],
@@ -264,7 +263,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "id": "11de8ee9",
       "metadata": {},
       "outputs": [],
@@ -299,7 +298,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": null,
       "id": "fb22e686",
       "metadata": {},
       "outputs": [],
@@ -320,7 +319,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "id": "0ca4f33c",
       "metadata": {},
       "outputs": [],
@@ -339,7 +338,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "id": "4a33d614",
       "metadata": {},
       "outputs": [],
@@ -365,7 +364,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "id": "adeebd97",
       "metadata": {},
       "outputs": [],
@@ -383,7 +382,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "id": "071d1141",
       "metadata": {},
       "outputs": [],
@@ -401,7 +400,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "id": "5125a794",
       "metadata": {},
       "outputs": [],
@@ -421,7 +420,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "id": "05a56d9b",
       "metadata": {},
       "outputs": [],
@@ -433,7 +432,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": null,
       "id": "53c5cac8",
       "metadata": {},
       "outputs": [],
@@ -451,7 +450,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": null,
       "id": "e90dfaf0",
       "metadata": {},
       "outputs": [],
@@ -481,7 +480,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": null,
       "id": "a0f60a5d",
       "metadata": {},
       "outputs": [],
@@ -501,7 +500,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": null,
       "id": "857354ca",
       "metadata": {},
       "outputs": [],
@@ -554,7 +553,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": null,
       "id": "d86ebf5b",
       "metadata": {},
       "outputs": [],
@@ -579,7 +578,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": null,
       "id": "67bc3465",
       "metadata": {},
       "outputs": [],
@@ -625,7 +624,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": null,
       "id": "1405d3b4",
       "metadata": {},
       "outputs": [],
@@ -722,7 +721,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 23,
+      "execution_count": null,
       "id": "9686be3c",
       "metadata": {},
       "outputs": [],
@@ -732,7 +731,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 24,
+      "execution_count": null,
       "id": "46366909",
       "metadata": {},
       "outputs": [],
@@ -759,7 +758,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 25,
+      "execution_count": null,
       "id": "88ced78a",
       "metadata": {},
       "outputs": [],

--- a/notebooks/movie-recommendation/notebook.ipynb
+++ b/notebooks/movie-recommendation/notebook.ipynb
@@ -53,7 +53,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "id": "039f0b97",
       "metadata": {},
       "outputs": [],
@@ -79,7 +79,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "id": "3e763118",
       "metadata": {},
       "outputs": [],
@@ -114,7 +114,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "id": "3e21f911",
       "metadata": {},
       "outputs": [],
@@ -155,7 +155,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 4,
       "id": "fe23f570",
       "metadata": {},
       "outputs": [],
@@ -196,7 +196,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 5,
       "id": "f7e76f0f",
       "metadata": {},
       "outputs": [],
@@ -240,7 +240,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 6,
       "id": "9b7d1d50",
       "metadata": {},
       "outputs": [],
@@ -263,7 +263,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 7,
       "id": "11de8ee9",
       "metadata": {},
       "outputs": [],
@@ -298,7 +298,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 8,
       "id": "fb22e686",
       "metadata": {},
       "outputs": [],
@@ -319,7 +319,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 9,
       "id": "0ca4f33c",
       "metadata": {},
       "outputs": [],
@@ -338,7 +338,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 10,
       "id": "4a33d614",
       "metadata": {},
       "outputs": [],
@@ -364,7 +364,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 11,
       "id": "adeebd97",
       "metadata": {},
       "outputs": [],
@@ -382,7 +382,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 12,
       "id": "071d1141",
       "metadata": {},
       "outputs": [],
@@ -400,7 +400,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 13,
       "id": "5125a794",
       "metadata": {},
       "outputs": [],
@@ -420,7 +420,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 14,
       "id": "05a56d9b",
       "metadata": {},
       "outputs": [],
@@ -432,7 +432,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 15,
       "id": "53c5cac8",
       "metadata": {},
       "outputs": [],
@@ -450,7 +450,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 16,
       "id": "e90dfaf0",
       "metadata": {},
       "outputs": [],
@@ -480,7 +480,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 17,
       "id": "a0f60a5d",
       "metadata": {},
       "outputs": [],
@@ -500,7 +500,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 18,
       "id": "857354ca",
       "metadata": {},
       "outputs": [],
@@ -553,7 +553,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 19,
       "id": "d86ebf5b",
       "metadata": {},
       "outputs": [],
@@ -578,7 +578,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 20,
       "id": "67bc3465",
       "metadata": {},
       "outputs": [],
@@ -602,7 +602,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 21,
       "id": "cc8db25d",
       "metadata": {},
       "outputs": [],
@@ -624,7 +624,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 22,
       "id": "1405d3b4",
       "metadata": {},
       "outputs": [],
@@ -721,7 +721,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 23,
       "id": "9686be3c",
       "metadata": {},
       "outputs": [],
@@ -731,7 +731,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 24,
       "id": "46366909",
       "metadata": {},
       "outputs": [],
@@ -758,7 +758,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 25,
       "id": "88ced78a",
       "metadata": {},
       "outputs": [],

--- a/notebooks/movie-recommendation/notebook.ipynb
+++ b/notebooks/movie-recommendation/notebook.ipynb
@@ -1,8 +1,8 @@
 {
   "cells": [
     {
-      "id": "0826a622",
       "cell_type": "markdown",
+      "id": "0826a622",
       "metadata": {},
       "source": [
         "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(255, 182, 176, 0.25); padding: 5px;\">\n",
@@ -18,6 +18,7 @@
     },
     {
       "cell_type": "markdown",
+      "id": "bd3c1a79",
       "metadata": {},
       "source": [
         "<div class=\"alert alert-block alert-info\">\n",
@@ -27,11 +28,11 @@
         "        <p>This tutorial is meant for Standard & Premium Workspaces. You can't run this with a Free Starter Workspace due to restrictions on Storage. Create a Workspace using +group in the left nav & select Standard for this notebook. Gallery notebooks tagged with \"Starter\" are suitable to run on a Free Starter Workspace </p>\n",
         "    </div>\n",
         "</div>"
-      ],
-      "id": "bd3c1a79"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "9039eecb",
       "metadata": {},
       "source": [
         "*Source*: [Full MovieLens 25M Dataset](https://grouplens.org/datasets/movielens/25m/) - [Appplication](https://movie-recommender-flask-t954.vercel.app/)\n",
@@ -39,59 +40,59 @@
         "This notebook demonstrates how SingleStoreDB helps you build a simple Movie Recommender System.\n",
         "\n",
         "<img src=https://raw.githubusercontent.com/singlestore-labs/spaces-notebooks/master/notebooks/movie-recommendation/images/database-tables.png width=\"1000\">"
-      ],
-      "id": "9039eecb"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "eee7cef6",
       "metadata": {},
       "source": [
         "## 1. Install required libraries\n",
         "\n",
         "Install the library for vectorizing the data (up to 2 minutes)."
-      ],
-      "id": "eee7cef6"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 1,
+      "id": "039f0b97",
       "metadata": {},
       "outputs": [],
       "source": [
         "!pip install sentence-transformers --quiet"
-      ],
-      "id": "039f0b97"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "82ddb890",
       "metadata": {},
       "source": [
         "## 2. Create database and ingest data"
-      ],
-      "id": "82ddb890"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "d3181151",
       "metadata": {},
       "source": [
         "Create the `movie_recommender` database."
-      ],
-      "id": "d3181151"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 2,
+      "id": "3e763118",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
         "DROP DATABASE IF EXISTS movie_recommender;\n",
         "CREATE DATABASE IF NOT EXISTS movie_recommender;"
-      ],
-      "id": "3e763118"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "339bf265",
       "metadata": {},
       "source": [
         "<div class=\"alert alert-block alert-warning\">\n",
@@ -102,20 +103,20 @@
         "        It updates the <tt>connection_url</tt> which is used by the <tt>%%sql</tt> magic command and SQLAlchemy to make connections to the selected database.</p>\n",
         "    </div>\n",
         "</div>"
-      ],
-      "id": "339bf265"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "3fda9e9d",
       "metadata": {},
       "source": [
         "Create `tags` table and start pipeline."
-      ],
-      "id": "3fda9e9d"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 3,
+      "id": "3e21f911",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -143,20 +144,20 @@
         "    (userId, movieId, tag, timestamp);\n",
         "\n",
         "START PIPELINE tags;"
-      ],
-      "id": "3e21f911"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "9321b7e3",
       "metadata": {},
       "source": [
         "Create `ratings` table and start pipeline."
-      ],
-      "id": "9321b7e3"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 4,
+      "id": "fe23f570",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -184,20 +185,20 @@
         "    (userId, movieId, rating, timestamp);\n",
         "\n",
         "START PIPELINE ratings;"
-      ],
-      "id": "fe23f570"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "b23fd64b",
       "metadata": {},
       "source": [
         "Create `movies` table and start pipeline."
-      ],
-      "id": "b23fd64b"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 5,
+      "id": "f7e76f0f",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -225,23 +226,23 @@
         "    (movieId, title, genres);\n",
         "\n",
         "START PIPELINE movies;"
-      ],
-      "id": "f7e76f0f"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "25876eb6",
       "metadata": {},
       "source": [
         "### Check that all the data has been loaded\n",
         "\n",
         "There should be 25m rows for ratings, 62k for movies and 1m for tags. If the values are less than that, try the query\n",
         "again in a few seconds, the pipelines are still running."
-      ],
-      "id": "25876eb6"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 6,
+      "id": "9b7d1d50",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -251,20 +252,20 @@
         "SELECT COUNT(*) AS count_rows FROM movies\n",
         "UNION ALL\n",
         "SELECT COUNT(*) AS count_rows FROM tags"
-      ],
-      "id": "9b7d1d50"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "3a2ee35a",
       "metadata": {},
       "source": [
         "### Concatenate `tags` and `movies` tables using all tags"
-      ],
-      "id": "3a2ee35a"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 7,
+      "id": "11de8ee9",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -278,68 +279,68 @@
         "    FROM movies m\n",
         "    LEFT JOIN tags t ON m.movieId = t.movieId\n",
         "    GROUP BY m.movieId, m.title, m.genres;"
-      ],
-      "id": "11de8ee9"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "8bd899ae",
       "metadata": {},
       "source": [
         "## 3. Vectorize data"
-      ],
-      "id": "8bd899ae"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "f4a0cd2d",
       "metadata": {},
       "source": [
         "Initialize sentence transformer."
-      ],
-      "id": "f4a0cd2d"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 8,
+      "id": "fb22e686",
       "metadata": {},
       "outputs": [],
       "source": [
         "from sentence_transformers import SentenceTransformer\n",
         "\n",
         "model = SentenceTransformer('flax-sentence-embeddings/all_datasets_v3_mpnet-base')"
-      ],
-      "id": "fb22e686"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "80b88943",
       "metadata": {},
       "source": [
         "Query the `movies_with_tags` table and store the output in a variable named `result`. The `result <<` syntax in the\n",
         "`%%sql` line indicates that the output from the query should get stored under that variable name."
-      ],
-      "id": "80b88943"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 9,
+      "id": "0ca4f33c",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql result <<\n",
         "SELECT * FROM movies_with_tags"
-      ],
-      "id": "0ca4f33c"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "5347eef3",
       "metadata": {},
       "source": [
         "Convert the result from the above SQL into a DataFrame and clean up quotes."
-      ],
-      "id": "5347eef3"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 10,
+      "id": "4a33d614",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -352,106 +353,106 @@
         "df['allTags'] = df['allTags'].str.replace('\"', '').str.replace(\"'\", '')\n",
         "\n",
         "data = df.to_dict(orient='records')"
-      ],
-      "id": "4a33d614"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "17c90ea9",
       "metadata": {},
       "source": [
         "Check the first row of the list."
-      ],
-      "id": "17c90ea9"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 11,
+      "id": "adeebd97",
       "metadata": {},
       "outputs": [],
       "source": [
         "data[0]"
-      ],
-      "id": "adeebd97"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "de736010",
       "metadata": {},
       "source": [
         "Concatenate title and tags."
-      ],
-      "id": "de736010"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 12,
+      "id": "071d1141",
       "metadata": {},
       "outputs": [],
       "source": [
         "all_title_type_column = [f'{row[\"title\"]}-{row[\"allTags\"]}' if row[\"title\"] is not None else row[\"title\"] for row in data]"
-      ],
-      "id": "071d1141"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "e266fe5c",
       "metadata": {},
       "source": [
         "Create the embeddings for Title & Tag (~3 minutes)."
-      ],
-      "id": "e266fe5c"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 13,
+      "id": "5125a794",
       "metadata": {},
       "outputs": [],
       "source": [
         "# Remove [:3000] if you want to vectorize all rows (~60 minutes)\n",
         "all_embeddings = model.encode(all_title_type_column[:3000])\n",
         "all_embeddings.shape"
-      ],
-      "id": "5125a794"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "97f49fdc",
       "metadata": {},
       "source": [
         "Merge the original data with the vector data."
-      ],
-      "id": "97f49fdc"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 14,
+      "id": "05a56d9b",
       "metadata": {},
       "outputs": [],
       "source": [
         "# Remember the list will be only 3,000 elements\n",
         "for row, embedding in zip(data, all_embeddings):\n",
         "    row['embedding'] = embedding"
-      ],
-      "id": "05a56d9b"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 15,
+      "id": "53c5cac8",
       "metadata": {},
       "outputs": [],
       "source": [
         "data[0]"
-      ],
-      "id": "53c5cac8"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "83ae8f78",
       "metadata": {},
       "source": [
         "## 4. Create table for movie information and vectors"
-      ],
-      "id": "83ae8f78"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 16,
+      "id": "e90dfaf0",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -465,43 +466,43 @@
         "    allTags longtext CHARACTER SET utf8mb4,\n",
         "    vector BLOB\n",
         ")"
-      ],
-      "id": "e90dfaf0"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "d86c3ab9",
       "metadata": {},
       "source": [
         "Create a database connection using SQLAlchemy. We are going to use an SQLAlchemy connection here because one\n",
         "column of data is numpy arrays. The SingleStoreDB SQLAlchemy driver will automatically convert those to\n",
         "the correct binary format when uploading, so it's a bit more convenient than doing the conversions and\n",
         "formatting manually for the `%sql` magic command."
-      ],
-      "id": "d86c3ab9"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 17,
+      "id": "a0f60a5d",
       "metadata": {},
       "outputs": [],
       "source": [
         "from singlestoredb import create_engine\n",
         "\n",
         "conn = create_engine().connect()"
-      ],
-      "id": "a0f60a5d"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "8d09c8e9",
       "metadata": {},
       "source": [
         "Insert the data. Some rows might encounter errors due to unsupported characters."
-      ],
-      "id": "8d09c8e9"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 18,
+      "id": "857354ca",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -525,36 +526,36 @@
         "    ''')\n",
         "\n",
         "conn.execute(sql_query, data[:3000])"
-      ],
-      "id": "857354ca"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "35d9e0ab",
       "metadata": {},
       "source": [
-        "## 5. Marrying Search \u2764\ufe0f Semantic Search \u2764\ufe0f Analytics"
-      ],
-      "id": "35d9e0ab"
+        "## 5. Marrying Search ❤️ Semantic Search ❤️ Analytics"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "f4d0f756",
       "metadata": {},
       "source": [
         "### Build autocomplete search"
-      ],
-      "id": "f4d0f756"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "88fb5547",
       "metadata": {},
       "source": [
         "This is en experimentat we started with to render a full text search."
-      ],
-      "id": "88fb5547"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 19,
+      "id": "d86ebf5b",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -566,20 +567,20 @@
         "                ORDER BY relevance DESC\n",
         "                LIMIT 10)\n",
         "    SELECT title, movieId FROM queryouter;"
-      ],
-      "id": "d86ebf5b"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "482c813e",
       "metadata": {},
       "source": [
         "### Create user favorite movie tables"
-      ],
-      "id": "482c813e"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 20,
+      "id": "67bc3465",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -590,42 +591,42 @@
         "    ts datetime DEFAULT NULL,\n",
         "    KEY userid (userid)\n",
         ")"
-      ],
-      "id": "67bc3465"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "ee7b2569",
       "metadata": {},
       "source": [
         "Enter dummy data for testing purposes."
-      ],
-      "id": "ee7b2569"
+      ]
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": null,
+      "id": "cc8db25d",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
         "INSERT INTO user_choice (userid, title, ts)\n",
-        "    VALUES ('user1', 'Zone 39 (1997)', '2022-01-01 00:00:00'),\n",
-        "           ('user1', 'Star Trek II: The Wrath of Khan (1982)', '2022-01-01 00:00:00'),\n",
-        "           ('user1', 'Giver, The (2014)', '2022-01-01 00:00:00');"
-      ],
-      "id": "cc8db25d"
+        "    VALUES ('user1', 'Mr Reliable (1997)', '2022-01-01 00:00:00'),\n",
+        "           ('user1', 'Beastly (2011)', '2022-01-01 00:00:00'),\n",
+        "           ('user1', 'Harvest/La Cosecha, The (2011)', '2022-01-01 00:00:00');"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "549dd511",
       "metadata": {},
       "source": [
         "### Build semantic search for a movie recommendation"
-      ],
-      "id": "549dd511"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 22,
+      "id": "1405d3b4",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -709,30 +710,30 @@
         "    dc.Rating_Match DESC\n",
         "LIMIT\n",
         "    5;"
-      ],
-      "id": "1405d3b4"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "db8a6e82",
       "metadata": {},
       "source": [
         "## 6. What are you looking for?"
-      ],
-      "id": "db8a6e82"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 23,
+      "id": "9686be3c",
       "metadata": {},
       "outputs": [],
       "source": [
         "search_embedding = model.encode(\"I want see a French comedy movie\")"
-      ],
-      "id": "9686be3c"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 24,
+      "id": "46366909",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -746,31 +747,30 @@
         "\n",
         "for i, res in enumerate(results):\n",
         "    print(f\"{i + 1}: {res.title} {res.genres} Score: {res.score}\")"
-      ],
-      "id": "46366909"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "f44af172",
       "metadata": {},
       "source": [
         "## Clean up"
-      ],
-      "id": "f44af172"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 25,
+      "id": "88ced78a",
       "metadata": {},
       "outputs": [],
       "source": [
         "%%sql\n",
         "DROP DATABASE IF EXISTS movie_recommender"
-      ],
-      "id": "88ced78a"
+      ]
     },
     {
-      "id": "f678873e",
       "cell_type": "markdown",
+      "id": "f678873e",
       "metadata": {},
       "source": [
         "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",

--- a/notebooks/movie-recommendation/notebook.ipynb
+++ b/notebooks/movie-recommendation/notebook.ipynb
@@ -1,8 +1,8 @@
 {
   "cells": [
     {
-      "cell_type": "markdown",
       "id": "0826a622",
+      "cell_type": "markdown",
       "metadata": {},
       "source": [
         "<div id=\"singlestore-header\" style=\"display: flex; background-color: rgba(255, 182, 176, 0.25); padding: 5px;\">\n",
@@ -27,7 +27,8 @@
         "        <p>This tutorial is meant for Standard & Premium Workspaces. You can't run this with a Free Starter Workspace due to restrictions on Storage. Create a Workspace using +group in the left nav & select Standard for this notebook. Gallery notebooks tagged with \"Starter\" are suitable to run on a Free Starter Workspace </p>\n",
         "    </div>\n",
         "</div>"
-      ]
+      ],
+      "id": "94047d8f"
     },
     {
       "cell_type": "markdown",
@@ -532,7 +533,7 @@
       "id": "35d9e0ab",
       "metadata": {},
       "source": [
-        "## 5. Marrying Search ❤️ Semantic Search ❤️ Analytics"
+        "## 5. Marrying Search \u2764\ufe0f Semantic Search \u2764\ufe0f Analytics"
       ]
     },
     {
@@ -768,8 +769,8 @@
       ]
     },
     {
-      "cell_type": "markdown",
       "id": "f678873e",
+      "cell_type": "markdown",
       "metadata": {},
       "source": [
         "<div id=\"singlestore-footer\" style=\"background-color: rgba(194, 193, 199, 0.25); height:2px; margin-bottom:10px\"></div>\n",


### PR DESCRIPTION
Updated user INSERT INTO SQL for example to properly render output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook tweak to sample INSERT values and ipynb formatting; no application or infrastructure impact.
> 
> **Overview**
> Updates the movie-recommendation tutorial notebook so the **dummy `user_choice` seed data** uses three titles that align with movies present in the vectorized subset (`movie_with_tags_with_vectors`, first 3,000 rows). The prior example titles could fail the inner join in the semantic recommendation query and produce empty or misleading demo output.
> 
> The rest of the diff is **notebook JSON housekeeping**: cell `id` fields are reordered in the `.ipynb` structure with no change to SQL, Python, or tutorial steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ca18e2566235e1e3ad1be0b0f2f5999180ecf0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->