### PR TITLE
refact: enhance SingleStore cheat sheet notebook

### DIFF
--- a/notebooks/singlestore-cheat-sheet/notebook.ipynb
+++ b/notebooks/singlestore-cheat-sheet/notebook.ipynb
@@ -289,6 +289,20 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "id": "b791f201",
+      "source": [
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n",
+        "    <div>\n",
+        "        <p><b>Action Required</b></p>\n",
+        "        <p>Before running the pipeline examples below, be sure to select your database from the drop-down list at the top of this notebook. This updates the <tt>connection_url</tt> which is used by the <tt>%%sql</tt> magic command to connect to the selected database.</p>\n",
+        "    </div>\n",
+        "</div>"
+      ],
+      "metadata": {}
+    },
+    {
       "attachments": {},
       "cell_type": "markdown",
       "id": "6f274e44",

--- a/notebooks/singlestore-cheat-sheet/notebook.ipynb
+++ b/notebooks/singlestore-cheat-sheet/notebook.ipynb
@@ -323,9 +323,6 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "# Select the database used for pipeline testing.\n",
-        "USE database_name;\n",
-        "\n",
         "# Create the destination table for the S3 sample data.\n",
         "CREATE TABLE SalesData (\n",
         "    Date TEXT COLLATE utf8mb4_bin,\n",

--- a/notebooks/singlestore-cheat-sheet/notebook.ipynb
+++ b/notebooks/singlestore-cheat-sheet/notebook.ipynb
@@ -99,7 +99,7 @@
       "source": [
         "%%sql\n",
         "# Create Database\n",
-        "CREATE DATABASE database_name; -- Note this will not work on free tier due to one DB constraint"
+        "CREATE DATABASE database_name; # Note this will not work on free tier due to one DB constraint"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "source": [
         "%%sql\n",
         "# Drop Database\n",
-        "DROP DATABASE database_name; -- Use with extreme caution"
+        "DROP DATABASE database_name; # Use with extreme caution"
       ]
     },
     {
@@ -166,7 +166,7 @@
         "CREATE REFERENCE TABLE categories (\n",
         "    id INT PRIMARY KEY,\n",
         "    name VARCHAR(50)\n",
-        "    -- No SHARD KEY needed for reference tables\n",
+        "    # No SHARD KEY needed for reference tables\n",
         ");"
       ]
     },
@@ -184,7 +184,7 @@
         "    event_type VARCHAR(50),\n",
         "    ts DATETIME,\n",
         "    data JSON,\n",
-        "    SORT KEY (timestamp),\n",
+        "    SORT KEY (ts),\n",
         "    SHARD KEY (id)\n",
         ");"
       ]
@@ -323,7 +323,22 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "#Create Pipeline\n",
+        "# Select the database used for pipeline testing.\n",
+        "USE database_name;\n",
+        "\n",
+        "# Create the destination table for the S3 sample data.\n",
+        "CREATE TABLE SalesData (\n",
+        "    Date TEXT COLLATE utf8mb4_bin,\n",
+        "    Store_ID BIGINT DEFAULT NULL,\n",
+        "    ProductID TEXT COLLATE utf8mb4_bin,\n",
+        "    Product_Name TEXT COLLATE utf8mb4_bin,\n",
+        "    Product_Category TEXT COLLATE utf8mb4_bin,\n",
+        "    Quantity_Sold BIGINT DEFAULT NULL,\n",
+        "    Price FLOAT DEFAULT NULL,\n",
+        "    Total_Sales FLOAT DEFAULT NULL\n",
+        ");\n",
+        "\n",
+        "# Create Pipeline\n",
         "CREATE PIPELINE SalesData_Pipeline AS\n",
         "LOAD DATA S3 's3://singlestoreloaddata/SalesData/*.csv'\n",
         "CONFIG '{ \"region\": \"ap-south-1\" }'\n",
@@ -391,7 +406,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "STOP PIPELINE [IF RUNNING] pipeline_name [DETACH];"
+        "STOP PIPELINE IF RUNNING SalesData_Pipeline;"
       ]
     },
     {
@@ -411,7 +426,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "DROP PIPELINE [IF EXISTS] pipeline_name;"
+        "DROP PIPELINE IF EXISTS SalesData_Pipeline;"
       ]
     },
     {
@@ -497,66 +512,105 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
-      "id": "c6ea6895",
-      "metadata": {},
-      "outputs": [],
+      "id": "81b14fb3",
       "source": [
         "%%sql\n",
-        "# Vector search examples\n",
-        "# Find similar vectors using dot product\n",
-        "SELECT id, description, DOT_PRODUCT(embedding, '[0.1, 0.2, ...]') as similarity\n",
-        "FROM embeddings\n",
-        "ORDER BY similarity DESC\n",
-        "LIMIT 10;\n",
-        "\n",
-        "# Create a full-text index\n",
-        "ALTER TABLE embeddings ADD FULLTEXT USING VERSION 2 fts_idx(description);\n",
-        "\n",
-        "# Hybrid search combining full-text and vector search\n",
-        "SELECT id, description,\n",
-        "    DOT_PRODUCT(embedding, '[0.1, 0.2, ...]') as vector_score,\n",
-        "    MATCH(table embeddings) AGAINST('description:(\"search terms\")') as text_score\n",
-        "FROM embeddings\n",
-        "WHERE MATCH(table embeddings) AGAINST('description:(\"search terms\")')\n",
-        "ORDER BY (vector_score * 0.7 + text_score * 0.3) DESC;"
-      ]
+        "# Generate three valid 1,536-dimensional test vectors.\n",
+        "SET @v1 = CONCAT('[1,', RPAD('0,', 3068, '0,'), '0]');\n",
+        "SET @v2 = CONCAT('[0,1,', RPAD('0,', 3066, '0,'), '0]');\n",
+        "SET @v3 = CONCAT('[', RPAD('0,', 3070, '0,'), '1]');"
+      ],
+      "metadata": {},
+      "execution_count": 21,
+      "outputs": []
     },
     {
-      "attachments": {},
-      "cell_type": "markdown",
-      "id": "7405b7e6",
+      "cell_type": "code",
+      "id": "df337aa6",
+      "source": [
+        "%%sql\n",
+        "# Confirm that each test vector contains exactly 1,536 dimensions.\n",
+        "SELECT JSON_LENGTH(@v1) AS v1_dimensions,\n",
+        "       JSON_LENGTH(@v2) AS v2_dimensions,\n",
+        "       JSON_LENGTH(@v3) AS v3_dimensions;"
+      ],
       "metadata": {},
+      "execution_count": 22,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "id": "15b3905a",
+      "source": [
+        "%%sql\n",
+        "# Remove prior test rows so the example can be rerun cleanly.\n",
+        "DELETE FROM embeddings\n",
+        "WHERE id IN (1, 2, 3);"
+      ],
+      "metadata": {},
+      "execution_count": 23,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "id": "4183b7ee",
+      "source": [
+        "%%sql\n",
+        "# Insert sample descriptions and their corresponding test vectors.\n",
+        "INSERT INTO embeddings (id, description, embedding)\n",
+        "VALUES\n",
+        "(1, 'Vector search for product recommendations', @v1),\n",
+        "(2, 'Full-text search for product descriptions', @v2),\n",
+        "(3, 'Hybrid search combining vector and text search', @v3);"
+      ],
+      "metadata": {},
+      "execution_count": 24,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "id": "d8c4bb0b",
+      "source": [
+        "%%sql\n",
+        "# Rank rows by similarity to the first test vector.\n",
+        "SELECT id, description,\n",
+        "       DOT_PRODUCT(embedding, @v1) AS similarity\n",
+        "FROM embeddings\n",
+        "ORDER BY similarity DESC\n",
+        "LIMIT 10;"
+      ],
+      "metadata": {},
+      "execution_count": 25,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d88f6d69",
       "source": [
         "## SingleStore Kai (MongoDB API)\n",
         "\n",
         "### MongoDB Client Connection\n",
         "```\n",
         "mongodb://username:password@hostname:27017/database\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 22,
-      "id": "2d5df461",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# MongoDB-style commands\n",
+        "```\n",
         "\n",
-        "# Show databases\n",
+        "To run these commands:\n",
+        "\n",
+        "1. Open **Editor \u2192 Open Kai Shell**.\n",
+        "2. Select a Kai-enabled cluster.\n",
+        "3. Run the commands directly in Kai Shell.\n",
+        "\n",
+        "Kai Shell connects automatically, so no connection string or credentials are required.\n",
+        "\n",
+        "```javascript\n",
         "show dbs\n",
-        "\n",
-        "# Use database\n",
         "use mydb\n",
-        "\n",
-        "# Show collections\n",
         "show collections\n",
-        "\n",
-        "# Create collection\n",
-        "db.createCollection('users')"
-      ]
+        "db.createCollection(\"users\")\n",
+        "show collections\n",
+        "```"
+      ],
+      "metadata": {}
     },
     {
       "id": "2ab70470",


### PR DESCRIPTION
## Summary
- Changed SQL comment style from `--` to `#` for consistency throughout the notebook
- Fixed SORT KEY reference from 'timestamp' to 'ts' in columnstore table example
- Enhanced pipeline section with complete SalesData table schema
- Updated pipeline commands with specific, executable examples (STOP/DROP IF EXISTS)
- Added 5 new executable cells demonstrating vector operations with test data generation, insertion, and similarity search
- Improved Kai (MongoDB API) section with detailed instructions for using Kai Shell

## Test plan
- [ ] Run the notebook cells sequentially to verify all SQL commands execute correctly
- [ ] Verify vector operations cells generate and query test data successfully
- [ ] Confirm pipeline examples are clear and executable
- [ ] Check that all code formatting follows repository standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notebook edits with no production code, auth, or data-path changes.
> 
> **Overview**
> Updates the **SingleStore cheat sheet** notebook so examples are easier to run end-to-end and less placeholder-driven.
> 
> **SQL snippets:** Inline notes in `%%sql` cells switch from `--` to `#`, and the columnstore example’s `SORT KEY` now references the real `ts` column instead of `timestamp`.
> 
> **Pipelines:** Adds an **Action Required** callout to pick a database before pipeline cells. The create-pipeline cell now defines a `SalesData` destination table before `SalesData_Pipeline`, and stop/drop cells use concrete `IF RUNNING` / `IF EXISTS` syntax for that pipeline name.
> 
> **Vector search:** Replaces ellipsis-based queries with a short runnable flow—generate 1,536-d test vectors, verify dimensions, clean/insert sample rows, then rank with `DOT_PRODUCT(embedding, @v1)`.
> 
> **Kai (MongoDB API):** Drops the non-`%%sql` code cell in favor of markdown that explains opening Kai Shell and shows sample `show dbs` / `db.createCollection` commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da423d5e70529ff7d9387992f8fbee2259b38b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->