### PR TITLE
refact: enhance S3 CSV import notebook

### DIFF
--- a/notebooks/load-csv-data-s3-placeholder/notebook.ipynb
+++ b/notebooks/load-csv-data-s3-placeholder/notebook.ipynb
@@ -36,13 +36,14 @@
       "id": "4b3c156d",
       "metadata": {},
       "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n",
-        "    <div>\n",
-        "        <p><b>Input Credentials</b></p>\n",
-        "        <p>Define the <b>URL</b>, <b>REGION</b>, <b>ACCESS_KEY</b>, and <b>SECRET_ACCESS_KEY</b> variables below for integration, replacing the placeholder values with your own.</p>\n",
-        "    </div>\n",
-        "</div>"
+        "## Configure S3 credentials\n",
+        "\n",
+        "Set the S3 object URI, bucket region, and AWS credentials below.\n",
+        "\n",
+        "- For permanent IAM credentials, leave `SESSION_TOKEN = None`.\n",
+        "- For AWS SSO or other temporary credentials, provide the session token as well.\n",
+        "- Do not share or commit AWS credentials, especially in a shared workspace.\n",
+        "- `REGION` must match the S3 bucket's AWS Region."
       ]
     },
     {
@@ -52,10 +53,27 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "URL = 's3://your-bucket-name/your-data-file.csv'\n",
-        "REGION = 'your-region'\n",
-        "ACCESS_KEY = 'access_key_id'\n",
-        "SECRET_ACCESS_KEY = 'access_secret_key'"
+        "import json\n",
+        "\n",
+        "URL = 's3://your-bucket/sample_data.csv'\n",
+        "REGION = 'your-s3-bucket-region'\n",
+        "\n",
+        "ACCESS_KEY = 'your-access-key'\n",
+        "SECRET_ACCESS_KEY = 'your-secret-key'\n",
+        "\n",
+        "# Leave as None for permanent IAM credentials.\n",
+        "# Set this for AWS SSO or other temporary credentials.\n",
+        "SESSION_TOKEN = None\n",
+        "\n",
+        "credentials = {\n",
+        "    \"aws_access_key_id\": ACCESS_KEY,\n",
+        "    \"aws_secret_access_key\": SECRET_ACCESS_KEY,\n",
+        "}\n",
+        "\n",
+        "if SESSION_TOKEN:\n",
+        "    credentials[\"aws_session_token\"] = SESSION_TOKEN\n",
+        "\n",
+        "CREDENTIALS_JSON = json.dumps(credentials)"
       ]
     },
     {
@@ -92,7 +110,26 @@
       "source": [
         "##  Creating Table in SingleStore\n",
         "\n",
-        "Start by creating a table that will hold the data imported from S3."
+        "Start by creating a table that will hold the data imported from S3.\n",
+        "\n",
+        "## CSV requirements\n",
+        "\n",
+        "The CSV must:\n",
+        "\n",
+        "- Include this header exactly:\n",
+        "  `id,name,age,address,created_at`\n",
+        "- Contain five values in every data row.\n",
+        "- Quote text fields that contain commas.\n",
+        "- Include one header row.\n",
+        "- Contain no blank lines at the end of the file.\n",
+        "- Match the table schema below.\n",
+        "\n",
+        "Example:\n",
+        "\n",
+        "```csv\n",
+        "id,name,age,address,created_at\n",
+        "1,Alice,30,\"123 Main St\",\"2026-09-09 10:00:00\"\n",
+        "2,Bob,35,\"456 Oak Ave\",\"2026-09-09 10:05:00\""
       ]
     },
     {
@@ -103,7 +140,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "/* Feel free to change table name and schema */\n",
+        "# Feel free to change table name and schema\n",
         "\n",
         "CREATE TABLE IF NOT EXISTS my_table (\n",
         "    id INT,\n",
@@ -149,13 +186,13 @@
         "%%sql\n",
         "CREATE PIPELINE s3_import_pipeline\n",
         "AS LOAD DATA S3 '{{URL}}'\n",
-        "CONFIG '{\\\"REGION\\\":\\\"{{REGION}}\\\"}'\n",
-        "CREDENTIALS '{\\\"AWS_ACCESS_KEY_ID\\\": \\\"{{ACCESS_KEY}}\\\",\n",
-        "               \\\"AWS_SECRET_ACCESS_KEY\\\": \\\"{{SECRET_ACCESS_KEY}}\\\"}'\n",
+        "CONFIG '{\"REGION\":\"{{REGION}}\"}'\n",
+        "CREDENTIALS '{{CREDENTIALS_JSON}}'\n",
         "INTO TABLE my_table\n",
-        "FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\\\"'\n",
+        "FIELDS TERMINATED BY ','\n",
+        "OPTIONALLY ENCLOSED BY '\"'\n",
         "LINES TERMINATED BY '\\n'\n",
-        "IGNORE 1 lines;"
+        "IGNORE 1 LINES;"
       ]
     },
     {
@@ -199,7 +236,7 @@
       "outputs": [],
       "source": [
         "%%sql\n",
-        "SELECT * FROM my_table LIMIT 10;"
+        "SELECT * FROM my_table ORDER BY id;"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Improved credential configuration section with clearer step-by-step instructions
- Added support for AWS SSO and temporary credentials via `SESSION_TOKEN` parameter
- Added comprehensive CSV requirements section detailing exact format, quoting rules, and example data
- Changed credential handling to use `CREDENTIALS_JSON` variable for cleaner, more maintainable pipeline syntax
- Updated SQL comment style from `/* */` to `#` for consistency with other notebooks
- Added `ORDER BY id` to SELECT query for predictable, ordered results
- Improved placeholder values (e.g., `'your-bucket'` → `'your-bucket/sample_data.csv'`)

## Test plan
- [ ] Verify the notebook works with both permanent IAM credentials and temporary SSO credentials
- [ ] Test CSV upload with the example format provided
- [ ] Confirm pipeline creates and starts successfully with valid S3 credentials
- [ ] Verify data displays in correct order with ORDER BY clause

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notebook-only documentation and example code; no production services or security logic beyond clearer credential handling guidance.
> 
> **Overview**
> Updates the **load-csv-data-s3-placeholder** notebook so S3 setup and CSV expectations are clearer for users running the pipeline example.
> 
> The credentials section is rewritten as plain markdown (replacing the HTML warning block) and the setup cell now builds **`CREDENTIALS_JSON`** via `json.dumps`, with optional **`SESSION_TOKEN`** for temporary/SSO credentials. Placeholder values are refreshed (e.g. sample object path and region names), and the **`CREATE PIPELINE`** statement references that JSON instead of inline escaped key fields.
> 
> A **CSV requirements** section documents the exact header, quoting rules, and a sample file. Minor SQL tweaks include `#` comments, split **`FIELDS`/`OPTIONALLY ENCLOSED BY`** lines, **`IGNORE 1 LINES`**, and **`SELECT … ORDER BY id`** instead of a arbitrary **`LIMIT 10`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c41bf1283ce06660c5da1a1bf7f1153aa001294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->