### PR TITLE
Update Semantic Search with Hugging Face notebook

### DIFF
--- a/notebooks/semantic-search-with-hugging-face/notebook.ipynb
+++ b/notebooks/semantic-search-with-hugging-face/notebook.ipynb
@@ -34,11 +34,20 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "In this notebook, we will demonstrate an example of conducting semantic search on SingleStoreDB with SQL! Unlike traditional keyword-based search methods, semantic search algorithms take into account the relationships between words and their meanings, enabling them to deliver more accurate and relevant results \u2013 even when search terms are vague or ambiguous.\n",
+        "In this notebook you will build a working semantic search engine over movie reviews: Hugging Face turns text into vectors, and SingleStore stores and searches them with a single line of SQL.\n",
         "\n",
-        "SingleStoreDB\u2019s built-in parallelization and Intel SIMD-based vector processing takes care of the heavy lifting involved in processing vector data. This allows your to run your ML algorithms right in your database extremely efficiently with just 1 line of SQL!\n",
+        "**Keyword search** matches the characters you typed. If a review says \"hilarious\" and you search for \"funny\", keyword search finds nothing. **Semantic search** matches meaning instead. An embedding model converts each piece of text into a list of numbers \u2014 a *vector* \u2014 positioned so that texts with similar meanings land near each other. Finding relevant reviews then becomes a geometry question: which stored vectors point in most nearly the same direction as the vector for your query?\n",
         "\n",
-        "In this example, we use Hugging Face to create embeddings for our dataset and run semantic_search using dot_product vector matching function!"
+        "SingleStoreDB holds those vectors in a native `VECTOR` column and compares them with vector functions such as `DOT_PRODUCT`, executed in parallel across the cluster using Intel SIMD instructions. The search is ordinary SQL, so it composes with joins, filters, and aggregates over the rest of your data, and there is no separate vector database to operate alongside it.\n",
+        "\n",
+        "The path through this notebook:\n",
+        "\n",
+        "- create a database and install the embedding libraries\n",
+        "- load a small multilingual embedding model\n",
+        "- download 10,000 IMDB movie reviews and sample 100 of them\n",
+        "- turn each review into a 384-number vector\n",
+        "- store the reviews and their vectors in SingleStore\n",
+        "- search them by meaning with one SQL query"
       ],
       "id": "8930a289"
     },
@@ -96,9 +105,30 @@
       "source": [
         "## 3. Install and import required libraries\n",
         "\n",
-        "We will use an embedding model on Hugging Face with Sentence Transfomers library. We will be analysing the sentiment of reviewers of selected movies. This dataset is available on Hugging Face and to use it, we will need the datasets library.\n",
+        "The embedding model comes from Hugging Face and is loaded through the\n",
+        "[Sentence Transformers](https://sbert.net) library, which wraps a model together with the\n",
+        "post-processing needed to turn its raw token-by-token output into one vector per piece of\n",
+        "text.\n",
         "\n",
-        "The install process may take a couple minutes."
+        "Installing `sentence-transformers` also brings in `transformers` (the runtime that executes\n",
+        "the model) and `huggingface_hub` (which downloads model weights and datasets from the Hub),\n",
+        "so neither needs its own install line.\n",
+        "\n",
+        "The version bounds are matched to what the hosted notebook image ships, in particular its\n",
+        "PyTorch build. The cell prints the versions it ended up with and then checks that the model\n",
+        "runtime initialized, so any mismatch surfaces here rather than several cells later.\n",
+        "Loosening these bounds is the most likely way to break the notebook, so change them only if\n",
+        "you know the image has moved.\n",
+        "\n",
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "    <b class=\"fa fa-solid fa-exclamation-circle\"></b>\n",
+        "    <div>\n",
+        "        <p><b>Action Required</b></p>\n",
+        "        <p>If this cell fails, restart the kernel (<tt>Kernel &gt; Restart Kernel</tt>) and\n",
+        "        run it again \u2014 pip cannot replace modules that the running kernel has already\n",
+        "        imported.</p>\n",
+        "    </div>\n",
+        "</div>"
       ],
       "id": "f39d4c0d"
     },
@@ -108,18 +138,31 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install sentence-transformers==2.2.2 torch==2.2.0 tensorflow==2.15.0 datasets==2.15.0 --quiet\n",
+        "%pip install --quiet \"sentence-transformers>=5.0,<6\" \"transformers>=4.41,<5\"\n",
         "\n",
         "import json\n",
-        "import ibis\n",
+        "\n",
         "import numpy as np\n",
         "import pandas as pd\n",
+        "import pyarrow\n",
         "import sqlalchemy as sa\n",
         "import singlestoredb as s2\n",
         "import torch\n",
-        "from datasets import load_dataset\n",
-        "from transformers import AutoTokenizer\n",
-        "from transformers import AutoModel"
+        "import transformers\n",
+        "from huggingface_hub import hf_hub_download\n",
+        "from sentence_transformers import SentenceTransformer\n",
+        "\n",
+        "# Fail loudly and legibly if the install moved something the image needs held down.\n",
+        "print(f'torch {torch.__version__} | transformers {transformers.__version__} | '\n",
+        "      f'sentence-transformers {__import__(\"sentence_transformers\").__version__}')\n",
+        "print(f'numpy {np.__version__} | pyarrow {pyarrow.__version__} | pandas {pd.__version__}')\n",
+        "\n",
+        "assert transformers.utils.is_torch_available(), (\n",
+        "    f'transformers {transformers.__version__} disabled its PyTorch backend on torch '\n",
+        "    f'{torch.__version__}. Every model call below would fail. Pin a transformers release '\n",
+        "    f'that supports this torch, or upgrade torch.'\n",
+        ")\n",
+        "print('PyTorch backend active')"
       ],
       "id": "7c20b03d"
     },
@@ -127,9 +170,17 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## 4. Load Sentence Transformer library and create a function called `get_embedding()`\n",
+        "## 4. Load the embedding model and create a `get_embedding()` function\n",
         "\n",
-        "To vectorize and embed the reviews that watchers of the movies left, we will be using the `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` model. We will create a function called `get_embedding()` that will call this model and return the vectorized version of the sentence."
+        "We use `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`: a small, fast model\n",
+        "trained so that sentences which paraphrase one another sit close together in vector space,\n",
+        "across more than 50 languages. Every input, long or short, becomes a vector of 384 numbers.\n",
+        "\n",
+        "A transformer emits one vector per token, so something has to condense those into a single\n",
+        "vector for the whole text. This model's answer is mean pooling \u2014 average the token vectors,\n",
+        "counting only real tokens and not padding. `SentenceTransformer` reads that choice, and the\n",
+        "model's 128-token input limit, from the configuration published alongside the weights, which\n",
+        "is why we load the model this way rather than assembling the pieces by hand."
       ],
       "id": "1304a356"
     },
@@ -139,11 +190,17 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# Load Sentence Transformers model\n",
+        "# Sentence Transformers reads the pooling and truncation settings that ship with the\n",
+        "# model, so we get the model's intended behaviour rather than library defaults.\n",
         "model_name = \"sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2\"\n",
         "\n",
-        "model = AutoModel.from_pretrained(model_name)\n",
-        "tokenizer = AutoTokenizer.from_pretrained(model_name)"
+        "model = SentenceTransformer(model_name)\n",
+        "\n",
+        "# Ask the model for its output size rather than hard-coding 384, so the CREATE TABLE in\n",
+        "# step 7 always matches whichever model is loaded here.\n",
+        "EMBEDDING_DIM = int(model.encode('dimension probe').shape[0])\n",
+        "\n",
+        "print(f'{EMBEDDING_DIM} dimensions, up to {model.max_seq_length} tokens per input')"
       ],
       "id": "c67a6fb3"
     },
@@ -151,7 +208,14 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Add a function to compute the embedding. The result will be a numpy array of 32-bit floats."
+        "Now a small helper that embeds one string at a time. The result is a numpy array of\n",
+        "little-endian 32-bit floats, which is exactly the byte layout SingleStore's `VECTOR(N, F32)`\n",
+        "type expects, so it can be stored without any conversion.\n",
+        "\n",
+        "`normalize_embeddings=True` scales every vector to length 1. This is what makes the search\n",
+        "in step 8 work the way you want: for unit-length vectors, the dot product equals the cosine\n",
+        "of the angle between them. Scores then fall in a -1 to 1 range and mean \"how similar in\n",
+        "direction\", instead of also reflecting how long each vector happens to be."
       ],
       "id": "faaa17e1"
     },
@@ -161,12 +225,15 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "def get_embedding(sentence: str) -> np.ndarray[np.float32]:\n",
-        "    \"\"\"Retrieve embedding for given sentence.\"\"\"\n",
-        "    inputs = tokenizer(sentence, padding=True, truncation=True, return_tensors=\"pt\")\n",
-        "    with torch.no_grad():\n",
-        "        embedding = model(**inputs).last_hidden_state.mean(dim=1).squeeze().tolist()\n",
-        "    return np.array(embedding, dtype='<f4')"
+        "def get_embedding(sentence: str) -> np.ndarray:\n",
+        "    \"\"\"Retrieve a unit-length float32 embedding for the given sentence.\"\"\"\n",
+        "    embedding = model.encode(sentence, normalize_embeddings=True)\n",
+        "    return embedding.astype('<f4')\n",
+        "\n",
+        "\n",
+        "# Sanity check: a normalized vector has length 1.0\n",
+        "probe = get_embedding('a delightfully strange film')\n",
+        "print(probe.shape, probe.dtype, f'norm={np.linalg.norm(probe):.4f}')"
       ],
       "id": "63effe1c"
     },
@@ -174,9 +241,27 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## 5. Load the dataset on movie reviews from Hugging Face into a `DataFrame`\n",
+        "## 5. Load the dataset of movie reviews from Hugging Face into a `DataFrame`\n",
         "\n",
-        "We will be doing some operations and only sampling 100 random reviews from the \"test\" dataset of `imdb-movie-reviews`."
+        "`ajaykarthick/imdb-movie-reviews` is a collection of IMDB reviews, each labelled positive\n",
+        "or negative. Its splits are stored as plain JSONL files, so `hf_hub_download` fetches\n",
+        "`test.jsonl` (10,000 rows) from the Hub and pandas reads it directly. The file is cached\n",
+        "locally, so re-running this cell does not download it again.\n",
+        "\n",
+        "We then take a sample of 100 reviews to keep the embedding step quick. `random_state` fixes\n",
+        "which 100, so re-running the notebook gives you the same sample and therefore the same\n",
+        "search results.\n",
+        "\n",
+        "<div class=\"alert alert-block alert-info\">\n",
+        "    <b class=\"fa fa-solid fa-circle-info\"></b>\n",
+        "    <div>\n",
+        "        <p><b>Note</b></p>\n",
+        "        <p>IMDB reviews are long \u2014 around 1,270 characters on average, well past this\n",
+        "        model's 128-token limit \u2014 so only the opening of each review is embedded. That is\n",
+        "        fine for a demo, but a production system would split long documents into chunks and\n",
+        "        embed each chunk separately.</p>\n",
+        "    </div>\n",
+        "</div>"
       ],
       "id": "d3092600"
     },
@@ -186,12 +271,19 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# Load the dataset into a pandas DataFrame\n",
-        "dataset = load_dataset(\"ajaykarthick/imdb-movie-reviews\")\n",
-        "dataframe = dataset[\"train\"].to_pandas()\n",
+        "# Download the test split and read it with pandas\n",
+        "reviews_file = hf_hub_download(\n",
+        "    repo_id='ajaykarthick/imdb-movie-reviews',\n",
+        "    filename='test.jsonl',\n",
+        "    repo_type='dataset',\n",
+        ")\n",
+        "dataframe = pd.read_json(reviews_file, lines=True)\n",
         "\n",
         "sample_size = 100  # Adjust the desired sample size\n",
-        "random_sample = dataframe.sample(n=sample_size)"
+        "random_sample = dataframe.sample(n=sample_size, random_state=42).reset_index(drop=True)\n",
+        "\n",
+        "print(f'{len(dataframe)} reviews available, sampled {len(random_sample)}')\n",
+        "random_sample.head(3)"
       ],
       "id": "fcfaf2f0"
     },
@@ -199,9 +291,12 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## 6. Generate embeddings of the reviews left by customers and add them to your `DataFrame`\n",
+        "## 6. Generate embeddings of the reviews and add them to your `DataFrame`\n",
         "\n",
-        "We want to embed the entries in the `review` column and add the embeddings to the data. We will do this with pandas and our `get_embeddings` function. Embeddings are stored as a numpy array."
+        "Handing the whole column to `model.encode()` lets the model embed 32 reviews per forward\n",
+        "pass, which is much faster than calling `get_embedding()` once per row. `normalize_embeddings`\n",
+        "is set here for the same reason as in step 4: the stored vectors have to be unit length for\n",
+        "the dot product in step 8 to be a cosine similarity."
       ],
       "id": "d302c2b7"
     },
@@ -211,7 +306,16 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "random_sample['review_embeddings'] = random_sample['review'].apply(get_embedding)"
+        "embeddings = model.encode(\n",
+        "    random_sample['review'].tolist(),\n",
+        "    normalize_embeddings=True,\n",
+        "    batch_size=32,\n",
+        "    show_progress_bar=True,\n",
+        ").astype('<f4')\n",
+        "\n",
+        "random_sample['review_embeddings'] = list(embeddings)\n",
+        "\n",
+        "print(f'{len(embeddings)} embeddings of {embeddings.shape[1]} dimensions')"
       ],
       "id": "f7286972"
     },
@@ -219,11 +323,20 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## 7. Insert data into SingleStoreDB\n",
+        "## 7. Insert data into SingleStore\n",
         "\n",
-        "You can seamlessly bring this data to your SingleStoreDB table directly from your from `DataFrame`. SingleStore \u2665\ufe0f Python.\n",
+        "The embeddings go into a `VECTOR(384, F32)` column, SingleStore's native vector type. It\n",
+        "validates the dimension of every value on insert, prints readably in query results, and can\n",
+        "be backed by a vector index. `NOT NULL` is required if you want to add such an index later,\n",
+        "so it is worth declaring now.\n",
         "\n",
-        "We will bring this data into a table called `reviews`. Notice how you don't have to write any SQL for this\u00a0\u2013\u00a0we will infer the schema from your `DataFrame` and underneath the hood configure how to bring this `DataFrame` into our database. Since numpy arrays don't map directly to a database type, we give pandas a type hint to create a blob column for the `review_embeddings` column."
+        "Because the column type is the point, we write the `CREATE TABLE` ourselves rather than\n",
+        "letting pandas infer a schema. Each vector is then sent as a hex string and converted by\n",
+        "`UNHEX`, which hands SingleStore the packed 32-bit floats exactly as the model produced\n",
+        "them, with no text round-trip through the numbers.\n",
+        "\n",
+        "The second cell echoes the resulting table definition back, so you can see the vector column\n",
+        "as the database understands it."
       ],
       "id": "d49f2a7c"
     },
@@ -233,11 +346,33 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "random_sample.to_sql('reviews',\n",
-        "                     s2.create_engine().connect(),\n",
-        "                     if_exists='replace',\n",
-        "                     index=False,\n",
-        "                     dtype=dict(review_embeddings=sa.LargeBinary))"
+        "with s2.create_engine().connect() as conn:\n",
+        "    conn.execute(sa.text('DROP TABLE IF EXISTS reviews'))\n",
+        "    conn.execute(sa.text(f'''\n",
+        "        CREATE TABLE reviews (\n",
+        "            review            TEXT,\n",
+        "            label             BIGINT,\n",
+        "            review_embeddings VECTOR({EMBEDDING_DIM}, F32) NOT NULL\n",
+        "        )\n",
+        "    '''))\n",
+        "\n",
+        "    conn.execute(\n",
+        "        sa.text('''\n",
+        "            INSERT INTO reviews (review, label, review_embeddings)\n",
+        "            VALUES (:review, :label, UNHEX(:embedding))\n",
+        "        '''),\n",
+        "        [\n",
+        "            {\n",
+        "                'review': row.review,\n",
+        "                'label': int(row.label),\n",
+        "                'embedding': row.review_embeddings.tobytes().hex(),\n",
+        "            }\n",
+        "            for row in random_sample.itertuples()\n",
+        "        ],\n",
+        "    )\n",
+        "    conn.commit()\n",
+        "\n",
+        "print(f'Inserted {len(random_sample)} reviews')"
       ],
       "id": "333f4afa"
     },
@@ -260,7 +395,27 @@
       "source": [
         "## 8. Run the semantic search algorithm with just one line of SQL\n",
         "\n",
-        "We will utilize SingleStoreDB's distributed architecture to efficiently compute the dot product of the input string (stored in searchstring) with each entry in the database and return the top 5  reviews with the highest dot product score. Each vector is normalized to length 1, hence the dot product function essentially computes the cosine similarity between two vectors \u2013 an appropriate nearness metric. SingleStoreDB makes this extremely fast because it compiles queries to machine code and runs dot_product using SIMD instructions."
+        "Your search string goes through the same model as the reviews did, which puts it in the same\n",
+        "vector space. The query below then compares that one vector against all 100 stored vectors\n",
+        "and returns the five nearest.\n",
+        "\n",
+        "`<*>` is the infix operator for `DOT_PRODUCT`. Because every vector is unit length, the dot\n",
+        "product is the cosine similarity between your query and the review: scores near 1 mean\n",
+        "closely related in meaning, near 0 unrelated. SingleStore compiles the query to machine code\n",
+        "and evaluates the dot products with SIMD instructions, spread in parallel across the cluster.\n",
+        "\n",
+        "Try a search that shares no words at all with any review \u2014 `movies about space travel`, or\n",
+        "the same idea written in another language, since this model is multilingual. Matches you get\n",
+        "without a single word in common are the whole point of embedding search.\n",
+        "\n",
+        "With 100 rows this is an exact scan of the table, which is the right choice at this size. At\n",
+        "millions of rows you would add an approximate vector index to the same column, and the query\n",
+        "itself would not change:\n",
+        "\n",
+        "```sql\n",
+        "ALTER TABLE reviews ADD VECTOR INDEX ivf (review_embeddings)\n",
+        "    INDEX_OPTIONS '{\"index_type\":\"IVF_PQFS\", \"metric_type\":\"DOT_PRODUCT\"}';\n",
+        "```"
       ],
       "id": "371ad41b"
     },
@@ -274,12 +429,14 @@
         "\n",
         "search_embedding = get_embedding(searchstring).tobytes().hex()\n",
         "\n",
-        "results = %sql SELECT review, DOT_PRODUCT(review_embeddings, X'{{search_embedding}}') AS Score \\\n",
-        "               FROM reviews ORDER BY Score DESC LIMIT 5;\n",
+        "results = %sql SELECT review, review_embeddings <*> UNHEX('{{search_embedding}}') AS score \\\n",
+        "               FROM reviews ORDER BY score DESC LIMIT 5;\n",
         "\n",
         "print()\n",
         "for i, res in enumerate(results):\n",
-        "    print(f'{i + 1}: {res[0]} Score: {res[1]:.2f}\\n')"
+        "    review = ' '.join(res[0].split())\n",
+        "    excerpt = review[:300] + ('...' if len(review) > 300 else '')\n",
+        "    print(f'{i + 1}: [score {res[1]:.3f}] {excerpt}\\n')"
       ],
       "id": "2599d1bf"
     },


### PR DESCRIPTION
- Pin sentence-transformers/transformers to versions the hosted image supports, and assert the PyTorch backend initialized
- Store embeddings in a native VECTOR(384, F32) column via an explicit CREATE TABLE and UNHEX insert, instead of an inferred BLOB schema
- Normalize embeddings so DOT_PRODUCT is a cosine similarity, and use the <*> operator in the search query
- Derive the vector dimension from the loaded model
- Expand the markdown to explain keyword vs semantic search, mean pooling, the 128-token limit, and vector indexes
- Print search results as readable scored excerpts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and demo-notebook-only changes; no production services or shared libraries affected.
> 
> **Overview**
> **Refreshes the Semantic Search with Hugging Face notebook** so it matches current hosted-image dependencies, native SingleStore vectors, and clearer teaching narrative.
> 
> **Runtime and embeddings:** Dependency install moves to bounded `sentence-transformers` / `transformers` versions (drops pinned torch/tensorflow/datasets stack), prints versions, and **asserts the PyTorch backend is active**. Loading uses **`SentenceTransformer`** with **`normalize_embeddings=True`** and batched `encode()`; **`EMBEDDING_DIM`** is inferred from the model for schema alignment. IMDB data is loaded via **`hf_hub_download` + `test.jsonl`** with a fixed **`random_state`** sample.
> 
> **Storage and search:** Replaces **`pandas.to_sql` + BLOB inference** with an explicit **`VECTOR(N, F32) NOT NULL`** table and **`UNHEX`** inserts for packed float32 bytes. Search SQL switches to the **`<*>`** infix dot-product operator with **`UNHEX`**, and results print as **scored excerpts**.
> 
> **Docs:** Intro and step markdown are expanded (keyword vs semantic search, mean pooling, 128-token truncation, optional IVF vector index) plus kernel-restart and long-review notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6958e34d3c228e0323ab1ce99a97ead108302599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->